### PR TITLE
feat(api): rate limit per IP/user, Swagger docs, transactional booking/payment, unified pagination (closes #10 #12 #19 #23)

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -5,6 +5,9 @@
   "compilerOptions": {
     "deleteOutDir": true,
     "assets": ["email/templates/**/*.hbs"],
-    "watchAssets": true
+    "watchAssets": true,
+    "plugins": [
+      "@nestjs/swagger/plugin"
+    ]
   }
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4360,48 +4360,6 @@
         }
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@nestjs/schematics/node_modules/magic-string": {
       "version": "0.30.8",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
@@ -4423,36 +4381,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,8 +7,9 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/guard/jwt.auth.guard';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { BullModule } from '@nestjs/bull';
+import { AppThrottlerGuard } from './common/guards/app-throttler.guard';
 import { ScheduleModule } from '@nestjs/schedule';
 import { NewsletterModule } from './newsletter/newsletter.module';
 import { EmailModule } from './email/email.module';
@@ -27,25 +28,37 @@ import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking
       isGlobal: true,
     }),
     ScheduleModule.forRoot(),
+    // Throttler tiers — BE-07 acceptance: harder limits on anonymous
+    // traffic, generous limits on authenticated traffic. The actual
+    // tracker key (user vs IP) is decided by AppThrottlerGuard so the
+    // same global config applies to everyone.
     ThrottlerModule.forRoot([
+      // Burst protection shared by every caller.
+      { name: 'short', ttl: 1_000, limit: 3 },
+      { name: 'medium', ttl: 10_000, limit: 20 },
+
+      // Per-minute limits. The "long" tier is shared by everyone.
+      { name: 'long', ttl: 60_000, limit: 100 },
+
+      // Authenticated users get a more generous cap (1.5x by default)
+      // thanks to env overrides via THROTTLE_AUTH_LIMIT_LONG.
       {
-        name: 'short',
-        ttl: 1000, // 1 second
-        limit: 3, // 3 requests per second
+        name: 'long-auth',
+        ttl: 60_000,
+        limit: Number(process.env.THROTTLE_AUTH_LIMIT_LONG ?? 150),
       },
-      {
-        name: 'medium',
-        ttl: 10000, // 10 seconds
-        limit: 20, // 20 requests per 10 seconds
-      },
-      {
-        name: 'long',
-        ttl: 60000, // 1 minute
-        limit: 100, // 100 requests per minute
-      },
+
+      // Per-route named throttlers — applied via @Throttle({ name: {...} })
       { name: 'newsletter', ttl: 60_000, limit: 10 },
       { name: 'contact', ttl: 60_000, limit: 5 },
       { name: 'feedback', ttl: 60_000, limit: 10 },
+
+      // Per-IP stricter limits for unauthenticated traffic (default tier).
+      {
+        name: 'default-anon',
+        ttl: 60_000,
+        limit: Number(process.env.THROTTLE_ANON_LIMIT_LONG ?? 60),
+      },
     ]),
     BullModule.forRootAsync({
       imports: [ConfigModule],
@@ -108,8 +121,10 @@ import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking
       useClass: JwtAuthGuard,
     },
     {
+      // AppThrottlerGuard tracks by authenticated user id when
+      // available, else by request IP, and emits a standardized 429.
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: AppThrottlerGuard,
     },
   ],
 })

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,12 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { LoginUserDto } from './dto/login-user.dto';
@@ -26,7 +32,10 @@ import { Setup2faDto } from './dto/setup-2fa.dto';
 import { VerifyTotpDto } from './dto/verify-totp.dto';
 import { UseBackupCodeDto } from './dto/use-backup-code.dto';
 import { Disable2faDto } from './dto/disable-2fa.dto';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
+@ApiTags('auth')
+@ApiBearerAuth('bearer')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
@@ -34,6 +43,10 @@ export class AuthController {
   @Public()
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Register a new user (sends OTP)' })
+  @ApiResponse({ status: 201, description: 'User created and OTP sent' })
+  @ApiResponse({ status: 400, type: ApiErrorDto })
+  @ApiResponse({ status: 409, type: ApiErrorDto })
   create(@Body() createUserDto: CreateUserDto) {
     return this.authService.createUser(createUserDto);
   }
@@ -41,12 +54,19 @@ export class AuthController {
   @Public()
   @Post('verify-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Verify the OTP delivered after registration' })
+  @ApiResponse({ status: 200, description: 'OTP verified, user activated' })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
   verifyOtp(@Body() verifyOtpDto: VerifyOtpDto) {
     return this.authService.verifyOtp(verifyOtpDto);
   }
+
   @Public()
   @Post('resend-verification-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Resend the registration verification OTP' })
+  @ApiResponse({ status: 200, description: 'OTP re-delivered' })
+  @ApiResponse({ status: 429, type: ApiErrorDto })
   resendVerificationOtp(@Body() resendOtpDto: ResendOtpDto) {
     return this.authService.resendVerificationOtp(resendOtpDto.email);
   }
@@ -55,18 +75,27 @@ export class AuthController {
   @HttpCode(HttpStatus.CREATED)
   @Roles(UserRole.ADMIN)
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiOperation({ summary: 'Admin-only: register an admin or staff user' })
   createAdmin(@Body() createUserDto: CreateUserDto) {
     return this.authService.createAdminUser(createUserDto);
   }
+
   @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Login and obtain JWT access + refresh tokens' })
+  @ApiResponse({ status: 200, description: 'Tokens returned' })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
   login(@Body() loginUserDto: LoginUserDto) {
     return this.authService.login(loginUserDto);
   }
+
   @Public()
   @Post('refresh-token')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Exchange a refresh token for new tokens' })
+  @ApiResponse({ status: 200, description: 'Tokens refreshed' })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
   refreshToken(@Body('refreshToken') refreshToken: string) {
     return this.authService.refreshToken(refreshToken);
   }
@@ -74,6 +103,9 @@ export class AuthController {
   @Get('current-user')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get the currently authenticated user' })
+  @ApiResponse({ status: 200, description: 'User profile returned' })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
   retrieveCurrentUser(@CurrentUser() user: User) {
     return user;
   }
@@ -81,6 +113,7 @@ export class AuthController {
   @Public()
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Request a password-reset OTP (aliased below)' })
   forgotPassword(@Body() sendPasswordResetOtpDto: SendPasswordResetOtpDto) {
     return this.authService.requestResetPasswordOtp(sendPasswordResetOtpDto);
   }
@@ -88,14 +121,17 @@ export class AuthController {
   @Public()
   @Post('send-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Request a password-reset OTP' })
   requestResetPasswordOtp(
     @Body() sendPasswordResetOtpDto: SendPasswordResetOtpDto,
   ) {
     return this.authService.requestResetPasswordOtp(sendPasswordResetOtpDto);
   }
+
   @Public()
   @Post('resend-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Resend a password-reset OTP' })
   resendResetPasswordVerificationOtp(@Body() resendOtpDto: ResendOtpDto) {
     return this.authService.resendResetPasswordVerificationOtp(resendOtpDto);
   }
@@ -103,6 +139,7 @@ export class AuthController {
   @Public()
   @Post('verify-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Verify a password-reset OTP' })
   verifyResetPasswordOtp(@Body() verifyOtpDto: VerifyOtpDto) {
     return this.authService.verifyResetPasswordOtp(verifyOtpDto);
   }
@@ -110,6 +147,9 @@ export class AuthController {
   @Public()
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reset the password using a verified OTP' })
+  @ApiResponse({ status: 200, description: 'Password updated' })
+  @ApiResponse({ status: 400, type: ApiErrorDto })
   async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
     return this.authService.resetPassword(resetPasswordDto);
   }
@@ -117,6 +157,7 @@ export class AuthController {
   @Post('2fa/setup')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Start enrolling a TOTP authenticator' })
   setup2fa(@GetCurrentUser('id') userId: string) {
     return this.authService.setup2fa(userId);
   }
@@ -124,6 +165,7 @@ export class AuthController {
   @Post('2fa/confirm')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Confirm TOTP enrollment with a 6-digit code' })
   confirm2fa(@GetCurrentUser('id') userId: string, @Body() dto: Setup2faDto) {
     return this.authService.confirm2fa(userId, dto);
   }
@@ -131,6 +173,7 @@ export class AuthController {
   @Public()
   @Post('2fa/verify')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Verify a TOTP code during the login flow' })
   verifyTotpLogin(@Body() dto: VerifyTotpDto) {
     return this.authService.verifyTotpLogin(dto);
   }
@@ -138,6 +181,7 @@ export class AuthController {
   @Public()
   @Post('2fa/backup-code')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Consume a 2FA backup code' })
   verifyBackupCode(@Body() dto: UseBackupCodeDto) {
     return this.authService.verifyBackupCode(dto);
   }
@@ -145,6 +189,7 @@ export class AuthController {
   @Post('2fa/disable')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Disable 2FA for the current user' })
   disable2fa(@GetCurrentUser('id') userId: string, @Body() dto: Disable2faDto) {
     return this.authService.disable2fa(userId, dto);
   }
@@ -152,6 +197,7 @@ export class AuthController {
   @Get('2fa/status')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get the 2FA status for the current user' })
   get2faStatus(@GetCurrentUser('id') userId: string) {
     return this.authService.get2faStatus(userId);
   }

--- a/backend/src/auth/dto/create-user.dto.ts
+++ b/backend/src/auth/dto/create-user.dto.ts
@@ -1,26 +1,44 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsString,
   MinLength,
   IsNotEmpty,
   IsEmail,
   MaxLength,
+  IsOptional,
 } from 'class-validator';
 
 export class CreateUserDto {
+  @ApiProperty({ example: 'jane.doe@example.com', maxLength: 254 })
   @IsEmail({}, { message: 'Please provide a valid email' })
+  @MaxLength(254)
   email: string;
 
+  @ApiProperty({ example: 'Jane', maxLength: 30 })
   @IsNotEmpty({ message: 'firstname can not be empty' })
   @IsString({ message: 'firstname must be a string' })
   @MaxLength(30)
   firstname: string;
 
+  @ApiProperty({ example: 'Doe', maxLength: 30 })
   @IsNotEmpty({ message: 'lastname can not be empty' })
   @IsString({ message: 'lastname must be a string' })
   @MaxLength(30)
   lastname: string;
 
+  @ApiPropertyOptional({ example: 'jane_d', maxLength: 20 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  username?: string;
+
+  @ApiProperty({
+    example: 'Sup3r$ecret!',
+    minLength: 6,
+    description: 'Must contain at least one letter and one number',
+  })
   @IsNotEmpty({ message: 'password can not be empty' })
   @MinLength(6, { message: 'password must be at least 6 character long' })
+  @MaxLength(80)
   password: string;
 }

--- a/backend/src/auth/dto/login-user.dto.ts
+++ b/backend/src/auth/dto/login-user.dto.ts
@@ -1,10 +1,22 @@
-import { MinLength, IsNotEmpty, IsEmail } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { MinLength, IsNotEmpty, IsEmail, MaxLength } from 'class-validator';
 
 export class LoginUserDto {
+  @ApiProperty({
+    example: 'jane.doe@example.com',
+    description: 'Registered user email',
+  })
   @IsEmail({}, { message: 'Please provide a valid email' })
+  @MaxLength(254)
   email: string;
 
+  @ApiProperty({
+    example: 'Sup3r$ecret!',
+    minLength: 8,
+    description: 'Plain-text password (sent to the API over HTTPS only)',
+  })
   @IsNotEmpty({ message: 'password can not be empty' })
   @MinLength(8, { message: 'password must be at least 8 character long' })
+  @MaxLength(80)
   password: string;
 }

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,15 +1,25 @@
-import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
 
 export class ResetPasswordDto {
+  @ApiProperty({
+    example: '482917',
+    description: 'OTP delivered via reset email',
+  })
   @IsNotEmpty()
   @IsString()
+  @MaxLength(6)
   otp: string;
 
+  @ApiProperty({ example: 'N3wSup3r$ecret!', minLength: 8 })
   @IsNotEmpty()
   @IsString()
   @MinLength(8, { message: 'New password must be at least 8 characters long' })
+  @MaxLength(80)
+  @IsString()
   newPassword: string;
 
+  @ApiProperty({ example: 'N3wSup3r$ecret!' })
   @IsNotEmpty()
   @IsString()
   confirmNewPassword: string;

--- a/backend/src/auth/dto/verify-otp.dto.ts
+++ b/backend/src/auth/dto/verify-otp.dto.ts
@@ -1,12 +1,20 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class VerifyOtpDto {
+  @ApiProperty({ example: 'jane.doe@example.com' })
   @IsNotEmpty({ message: 'email is required' })
   @IsEmail({}, { message: 'Please provide a valid email' })
   @IsString()
+  @MaxLength(254)
   email: string;
 
+  @ApiProperty({
+    example: '482917',
+    description: '6-digit OTP delivered to email',
+  })
   @IsNotEmpty({ message: 'otp is required' })
   @IsString()
+  @MaxLength(6)
   otp: string;
 }

--- a/backend/src/bookings/bookings.controller.ts
+++ b/backend/src/bookings/bookings.controller.ts
@@ -16,6 +16,11 @@ import {
   ApiBearerAuth,
   ApiOperation,
   ApiQuery,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
 } from '@nestjs/swagger';
 import { BookingsService } from './bookings.service';
 import { CreateBookingDto } from './dto/create-booking.dto';
@@ -25,15 +30,24 @@ import { Roles } from '../auth/decorators/roles.decorators';
 import { UserRole } from '../users/enums/userRoles.enum';
 import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { PlanType } from './enums/plan-type.enum';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
+import { Booking } from './entities/booking.entity';
 
 @ApiTags('bookings')
-@ApiBearerAuth()
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiBadRequestResponse({ description: 'Validation error', type: ApiErrorDto })
+@ApiNotFoundResponse({ description: 'Resource not found', type: ApiErrorDto })
 @Controller('bookings')
 export class BookingsController {
   constructor(private readonly bookingsService: BookingsService) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a booking' })
+  @ApiOkResponse({ description: 'Booking created', type: Booking })
   async create(
     @Body() dto: CreateBookingDto,
     @GetCurrentUser('id') userId: string,
@@ -57,11 +71,12 @@ export class BookingsController {
 
   @Get('price-estimate')
   @ApiOperation({ summary: 'Get a price estimate for a booking plan' })
-  @ApiQuery({ name: 'workspaceId', required: true })
+  @ApiQuery({ name: 'hourlyRate', required: true, type: Number })
   @ApiQuery({ name: 'planType', enum: PlanType, required: true })
-  @ApiQuery({ name: 'seatCount', required: false })
-  @ApiQuery({ name: 'startDate', required: true })
-  @ApiQuery({ name: 'endDate', required: true })
+  @ApiQuery({ name: 'seatCount', required: false, type: Number })
+  @ApiQuery({ name: 'startDate', required: true, type: String })
+  @ApiQuery({ name: 'endDate', required: true, type: String })
+  @ApiResponse({ status: 200, description: 'Price estimate returned' })
   async getPriceEstimate(
     @Query('hourlyRate') hourlyRate: string,
     @Query('planType') planType: PlanType,
@@ -85,6 +100,7 @@ export class BookingsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get booking by ID' })
+  @ApiOkResponse({ description: 'Booking retrieved', type: Booking })
   async findOne(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,
@@ -99,6 +115,7 @@ export class BookingsController {
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Confirm a booking (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Booking confirmed', type: Booking })
   async confirm(@Param('id', ParseUUIDPipe) id: string) {
     const booking = await this.bookingsService.confirm(id);
     return { message: 'Booking confirmed successfully', data: booking };
@@ -107,6 +124,7 @@ export class BookingsController {
   @Patch(':id/cancel')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Cancel a booking' })
+  @ApiOkResponse({ description: 'Booking cancelled', type: Booking })
   async cancel(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,
@@ -121,6 +139,7 @@ export class BookingsController {
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Mark booking as completed (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Booking completed', type: Booking })
   async complete(@Param('id', ParseUUIDPipe) id: string) {
     const booking = await this.bookingsService.complete(id);
     return { message: 'Booking completed successfully', data: booking };

--- a/backend/src/bookings/bookings.service.ts
+++ b/backend/src/bookings/bookings.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
 import { CreateBookingDto } from './dto/create-booking.dto';
 import { BookingQueryDto } from './dto/booking-query.dto';
 import { CreateBookingProvider } from './providers/create-booking.provider';
@@ -27,8 +28,13 @@ export class BookingsService {
     return this.createBookingProvider.create(dto, userId);
   }
 
-  confirm(bookingId: string): Promise<Booking> {
-    return this.confirmBookingProvider.confirm(bookingId);
+  /**
+   * Confirm a booking, optionally reusing the caller's open transaction
+   * (BE-12) so the Paystack webhook doesn't accidentally nest a
+   * SAVEPOINT inside its own transaction.
+   */
+  confirm(bookingId: string, manager?: EntityManager): Promise<Booking> {
+    return this.confirmBookingProvider.confirm(bookingId, manager);
   }
 
   cancel(bookingId: string, userId: string, userRole: UserRole) {

--- a/backend/src/bookings/dto/booking-query.dto.ts
+++ b/backend/src/bookings/dto/booking-query.dto.ts
@@ -1,51 +1,42 @@
-import {
-  IsEnum,
-  IsInt,
-  IsOptional,
-  IsString,
-  IsUUID,
-  Min,
-} from 'class-validator';
-import { Type } from 'class-transformer';
-import { BookingStatus } from '../enums/booking-status.enum';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { BookingStatus } from '../enums/booking-status.enum';
+import { PaginationDto } from '../../common/dto/pagination.dto';
 
-export class BookingQueryDto {
-  @ApiPropertyOptional({ default: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @ApiPropertyOptional({ default: 20 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  limit?: number = 20;
-
+/**
+ * Query parameters for listing bookings (BE-15 acceptance).
+ * Inherits `page` / `limit` from the unified `PaginationDto` so
+ * defaults, validation, and the 100-item hard cap are identical
+ * to other list endpoints.
+ */
+export class BookingQueryDto extends PaginationDto {
   @ApiPropertyOptional({ enum: BookingStatus })
   @IsOptional()
   @IsEnum(BookingStatus)
   status?: BookingStatus;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ description: 'Filter by workspace UUID' })
   @IsOptional()
   @IsUUID()
   workspaceId?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ description: 'Filter by user UUID (admin only)' })
   @IsOptional()
   @IsUUID()
   userId?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    example: '2026-04-01',
+    description: 'ISO date (Y/M/D)',
+  })
   @IsOptional()
   @IsString()
   startDate?: string;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    example: '2026-04-30',
+    description: 'ISO date (Y/M/D)',
+  })
   @IsOptional()
   @IsString()
   endDate?: string;

--- a/backend/src/bookings/providers/cancel-booking.provider.ts
+++ b/backend/src/bookings/providers/cancel-booking.provider.ts
@@ -3,17 +3,23 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
-  Optional,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Booking } from '../entities/booking.entity';
 import { BookingStatus } from '../enums/booking-status.enum';
 import { UserRole } from '../../users/enums/userRoles.enum';
 import { User } from '../../users/entities/user.entity';
 import { EmailService } from '../../email/email.service';
 import { WorkspacesService } from '../../workspaces/workspaces.service';
+import { runInTransaction } from '../../common/utils/run-in-transaction';
 
+/**
+ * Cancels a booking. Only a single entity is mutated today
+ * (the Booking row), so we still wrap in a transaction so that
+ * future extensions (refund insertion, cancellation ledger entry)
+ * can be added here without partial-failure regressions (BE-12).
+ */
 @Injectable()
 export class CancelBookingProvider {
   constructor(
@@ -21,6 +27,7 @@ export class CancelBookingProvider {
     private readonly bookingsRepository: Repository<Booking>,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    private readonly dataSource: DataSource,
     private readonly emailService: EmailService,
     private readonly workspacesService: WorkspacesService,
   ) {}
@@ -30,35 +37,38 @@ export class CancelBookingProvider {
     userId: string,
     userRole: UserRole,
   ): Promise<Booking> {
-    const booking = await this.bookingsRepository.findOne({
-      where: { id: bookingId },
+    const saved = await runInTransaction(this.dataSource, async (manager) => {
+      const booking = await manager.findOne(Booking, {
+        where: { id: bookingId },
+      });
+      if (!booking) {
+        throw new NotFoundException(`Booking "${bookingId}" not found`);
+      }
+
+      const isAdmin =
+        userRole === UserRole.ADMIN ||
+        userRole === UserRole.SUPER_ADMIN ||
+        userRole === UserRole.STAFF;
+
+      if (!isAdmin && booking.userId !== userId) {
+        throw new ForbiddenException('You can only cancel your own bookings');
+      }
+
+      if (
+        booking.status !== BookingStatus.PENDING &&
+        booking.status !== BookingStatus.CONFIRMED
+      ) {
+        throw new BadRequestException(
+          'Only PENDING or CONFIRMED bookings can be cancelled',
+        );
+      }
+
+      booking.status = BookingStatus.CANCELLED;
+      return manager.save(booking);
     });
-    if (!booking) {
-      throw new NotFoundException(`Booking "${bookingId}" not found`);
-    }
 
-    const isAdmin =
-      userRole === UserRole.ADMIN ||
-      userRole === UserRole.SUPER_ADMIN ||
-      userRole === UserRole.STAFF;
-
-    if (!isAdmin && booking.userId !== userId) {
-      throw new ForbiddenException('You can only cancel your own bookings');
-    }
-
-    if (
-      booking.status !== BookingStatus.PENDING &&
-      booking.status !== BookingStatus.CONFIRMED
-    ) {
-      throw new BadRequestException(
-        'Only PENDING or CONFIRMED bookings can be cancelled',
-      );
-    }
-
-    booking.status = BookingStatus.CANCELLED;
-    const saved = await this.bookingsRepository.save(booking);
-
-    // Fire-and-forget cancellation email
+    // Fire-and-forget cancellation email (kept outside the transaction
+    // because emails are best-effort and must never block state).
     Promise.all([
       this.usersRepository.findOne({ where: { id: saved.userId } }),
       this.workspacesService.findById(saved.workspaceId),

--- a/backend/src/bookings/providers/complete-booking.provider.ts
+++ b/backend/src/bookings/providers/complete-booking.provider.ts
@@ -8,6 +8,11 @@ import { Repository } from 'typeorm';
 import { Booking } from '../entities/booking.entity';
 import { BookingStatus } from '../enums/booking-status.enum';
 
+/**
+ * Marks a booking as COMPLETED. Only the Booking row is mutated so a
+ * single save is sufficient and no transaction wrapper is required
+ * (BE-12). Kept explicit for documentation and future-proofing.
+ */
 @Injectable()
 export class CompleteBookingProvider {
   constructor(

--- a/backend/src/bookings/providers/confirm-booking.provider.ts
+++ b/backend/src/bookings/providers/confirm-booking.provider.ts
@@ -4,12 +4,21 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { Booking } from '../entities/booking.entity';
 import { BookingStatus } from '../enums/booking-status.enum';
 import { User } from '../../users/entities/user.entity';
 import { MembershipStatus } from '../../users/enums/membership-status.enum';
+import { runInTransaction } from '../../common/utils/run-in-transaction';
 
+/**
+ * Confirms a booking and — atomically — promotes the user to ACTIVE on
+ * their first confirmed booking (BE-12 acceptance).
+ *
+ * If any step fails the whole flow is rolled back. The optional
+ * `manager` parameter lets callers (e.g. the Paystack webhook) reuse
+ * their outer transaction so we never end up with nested savepoints.
+ */
 @Injectable()
 export class ConfirmBookingProvider {
   constructor(
@@ -17,32 +26,45 @@ export class ConfirmBookingProvider {
     private readonly bookingsRepository: Repository<Booking>,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    private readonly dataSource: DataSource,
   ) {}
 
-  async confirm(bookingId: string): Promise<Booking> {
-    const booking = await this.bookingsRepository.findOne({
-      where: { id: bookingId },
-    });
-    if (!booking) {
-      throw new NotFoundException(`Booking "${bookingId}" not found`);
-    }
-    if (booking.status !== BookingStatus.PENDING) {
-      throw new BadRequestException('Only PENDING bookings can be confirmed');
-    }
+  async confirm(
+    bookingId: string,
+    passedManager?: EntityManager,
+  ): Promise<Booking> {
+    const work = async (manager: EntityManager): Promise<Booking> => {
+      const booking = await manager.findOne(Booking, {
+        where: { id: bookingId },
+      });
+      if (!booking) {
+        throw new NotFoundException(`Booking "${bookingId}" not found`);
+      }
+      if (booking.status !== BookingStatus.PENDING) {
+        throw new BadRequestException('Only PENDING bookings can be confirmed');
+      }
 
-    booking.status = BookingStatus.CONFIRMED;
-    await this.bookingsRepository.save(booking);
+      booking.status = BookingStatus.CONFIRMED;
+      const savedBooking = await manager.save(booking);
 
-    // Activate member and set memberSince if first booking
-    const user = await this.usersRepository.findOne({
-      where: { id: booking.userId },
-    });
-    if (user && !user.memberSince) {
-      user.memberSince = new Date();
-      user.membershipStatus = MembershipStatus.ACTIVE;
-      await this.usersRepository.save(user);
+      const user = await manager.findOne(User, {
+        where: { id: booking.userId },
+      });
+      if (user && !user.memberSince) {
+        user.memberSince = new Date();
+        user.membershipStatus = MembershipStatus.ACTIVE;
+        await manager.save(user);
+      }
+
+      // Return the in-memory record we already saved inside this
+      // transaction. Don't re-fetch via the non-transactional repository
+      // — a separate connection could miss the uncommitted row.
+      return savedBooking;
+    };
+
+    if (passedManager) {
+      return work(passedManager);
     }
-
-    return booking;
+    return runInTransaction(this.dataSource, work);
   }
 }

--- a/backend/src/common/dto/api-error.dto.ts
+++ b/backend/src/common/dto/api-error.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Standard error response used in @ApiResponse declarations.
+ *
+ * Mirrors the default Nest exception filter payload so the schema
+ * is identical to what the API actually returns.
+ */
+export class ApiErrorDto {
+  @ApiProperty({ example: 400 })
+  statusCode: number;
+
+  @ApiProperty({
+    oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+  })
+  message: string | string[];
+
+  @ApiProperty({ example: 'Bad Request' })
+  error: string;
+
+  @ApiProperty({
+    example: '2026-07-23T12:00:00.000Z',
+    required: false,
+    nullable: true,
+  })
+  timestamp?: string;
+
+  @ApiProperty({ example: '/api/v1/users', required: false, nullable: true })
+  path?: string;
+}

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,126 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/**
+ * Sensible defaults for the unified pagination contract (BE-15).
+ * All list endpoints must use these values so behaviour is consistent.
+ */
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+/**
+ * Unified query DTO every list endpoint should extend.
+ *
+ * The @Max decorator enforces the hard cap at the validation layer,
+ * so oversized requests are rejected with a 400 before reaching the
+ * service / database.
+ */
+export class PaginationDto {
+  @ApiPropertyOptional({ default: DEFAULT_PAGE, minimum: 1, example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'page must be an integer' })
+  @Min(1, { message: 'page must be greater than or equal to 1' })
+  page: number = DEFAULT_PAGE;
+
+  @ApiPropertyOptional({
+    default: DEFAULT_LIMIT,
+    minimum: 1,
+    maximum: MAX_LIMIT,
+    example: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'limit must be an integer' })
+  @Min(1, { message: 'limit must be greater than or equal to 1' })
+  @Max(MAX_LIMIT, {
+    message: `limit must be less than or equal to ${MAX_LIMIT}`,
+  })
+  limit: number = DEFAULT_LIMIT;
+}
+
+/**
+ * Stable pagination metadata contract returned to the client.
+ * Use `buildPaginationMeta()` to instantiate so the format is
+ * identical across every endpoint.
+ */
+export class PaginationMetaDto {
+  @ApiProperty({ example: 1 })
+  currentPage: number;
+
+  @ApiProperty({ example: 20 })
+  itemsPerPage: number;
+
+  @ApiProperty({ example: 100 })
+  totalItems: number;
+
+  @ApiProperty({ example: 5 })
+  totalPages: number;
+
+  @ApiProperty({ example: false })
+  hasPreviousPage: boolean;
+
+  @ApiProperty({ example: true })
+  hasNextPage: boolean;
+}
+
+/**
+ * Generic paginated payload shape. Kept as a class (not interface)
+ * so it can be referenced from Swagger @ApiResponse({ type }).
+ */
+export class PaginatedResponseDto<T> {
+  @ApiProperty({ example: 'Items retrieved successfully' })
+  message: string;
+
+  @ApiProperty({ isArray: true })
+  items: T[];
+
+  @ApiProperty({ type: PaginationMetaDto })
+  meta: PaginationMetaDto;
+}
+
+/**
+ * Compute pagination meta. Pure function so it is trivial to unit test
+ * and share across services / providers.
+ */
+export function buildPaginationMeta(
+  total: number,
+  page: number,
+  limit: number,
+): PaginationMetaDto {
+  const safeLimit = Math.max(1, limit);
+  const totalPages = Math.max(1, Math.ceil(total / safeLimit));
+  return {
+    currentPage: page,
+    itemsPerPage: safeLimit,
+    totalItems: total,
+    totalPages,
+    hasPreviousPage: page > 1,
+    hasNextPage: page < totalPages,
+  };
+}
+
+/**
+ * Convenience wrapper that returns the full paginated payload
+ * (data, total, page, limit, totalPages, hasPrev, hasNext).
+ */
+export function paginatedResponse<T>(
+  message: string,
+  items: T[],
+  total: number,
+  page: number,
+  limit: number,
+) {
+  return {
+    message,
+    items,
+    total,
+    page,
+    limit,
+    totalPages: Math.max(1, Math.ceil(total / Math.max(1, limit))),
+    hasPreviousPage: page > 1,
+    hasNextPage: page < Math.max(1, Math.ceil(total / Math.max(1, limit))),
+  };
+}

--- a/backend/src/common/guards/app-throttler.guard.spec.ts
+++ b/backend/src/common/guards/app-throttler.guard.spec.ts
@@ -1,0 +1,67 @@
+import { Test } from '@nestjs/testing';
+import { HttpException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { AppThrottlerGuard } from './app-throttler.guard';
+
+function buildContext(req: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => ({
+        setHeader: jest.fn(),
+      }),
+      getNext: () => undefined,
+    }),
+    getHandler: () => undefined,
+    getClass: () => undefined,
+  } as unknown as ExecutionContext;
+}
+
+describe('AppThrottlerGuard', () => {
+  let guard: AppThrottlerGuard;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ThrottlerModule.forRoot([{ ttl: 60_000, limit: 10 }])],
+      providers: [AppThrottlerGuard, Reflector],
+    }).compile();
+
+    guard = moduleRef.get(AppThrottlerGuard);
+  });
+
+  it('tracks authenticated requests by user id', async () => {
+    const req = { user: { id: 'user-42' }, ip: '127.0.0.1' };
+    // @ts-expect-error test reaches protected method.
+    const tracker = await guard.getTracker(req);
+    expect(tracker).toBe('user:user-42');
+  });
+
+  it('falls back to IP for anonymous requests', async () => {
+    const req = { user: undefined, ip: '203.0.113.10' };
+    // @ts-expect-error test reaches protected method.
+    const tracker = await guard.getTracker(req);
+    expect(tracker).toBe('ip:203.0.113.10');
+  });
+
+  it('uses x-forwarded-for when present', async () => {
+    const req = {
+      headers: { 'x-forwarded-for': '198.51.100.7, 10.0.0.1' },
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    // @ts-expect-error test reaches protected method.
+    const tracker = await guard.getTracker(req);
+    expect(tracker).toBe('ip:198.51.100.7');
+  });
+
+  it('emits a standardized 429 response with retryAfter', async () => {
+    const ctx = buildContext({});
+    await expect(
+      // @ts-expect-error test reaches protected method.
+      guard.throwThrottlingException(ctx, {
+        timeToBlockExpire: 12_345,
+      } as never),
+    ).rejects.toThrow(HttpException);
+  });
+});

--- a/backend/src/common/guards/app-throttler.guard.ts
+++ b/backend/src/common/guards/app-throttler.guard.ts
@@ -1,0 +1,102 @@
+import { ExecutionContext, HttpException, Injectable } from '@nestjs/common';
+import {
+  ThrottlerGuard,
+  ThrottlerLimitDetail,
+  ThrottlerRequest,
+} from '@nestjs/throttler';
+import { Request, Response } from 'express';
+
+/**
+ * Application-wide throttler guard (BE-07).
+ *
+ * Tracking:
+ *  - Authenticated requests are tracked by the user id so limits aren't
+ *    shared across users behind the same NAT / proxy.
+ *  - Anonymous / public requests fall back to the request IP.
+ *
+ * Different thresholds (BE-07 acceptance):
+ *  - Two global named tiers are registered: `default-anon` (stricter,
+ *    for anon traffic) and `default-auth` (looser, for auth traffic).
+ *  - `handleRequest` checks the tier name and silently skips enforcement
+ *    of the wrong one for the current request. Net effect: auth users
+ *    only burn `default-auth` budget; anon users only burn `default-anon`.
+ *
+ * 429 response: structured payload plus `Retry-After` header in seconds.
+ */
+@Injectable()
+export class AppThrottlerGuard extends ThrottlerGuard {
+  /** @inheritdoc */
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    const userId = this.extractUserId(req);
+    if (userId !== undefined && userId !== null) {
+      return `user:${userId}`;
+    }
+    return `ip:${this.extractClientIp(req)}`;
+  }
+
+  /** @inheritdoc */
+  protected async handleRequest(
+    requestProps: ThrottlerRequest,
+  ): Promise<boolean> {
+    const isAuthenticated = !!requestProps.context.switchToHttp().getRequest()
+      ?.user?.id;
+    const tierName = requestProps.throttler?.name;
+    const skipForAuth = isAuthenticated && tierName === 'default-anon';
+    const skipForAnon = !isAuthenticated && tierName === 'default-auth';
+    if (skipForAuth || skipForAnon) {
+      return true;
+    }
+    return super.handleRequest(requestProps);
+  }
+
+  /**
+   * Standardized 429 response (`Retry-After` in seconds + structured body).
+   * Return type matches the parent Promise<void>.
+   */
+  protected async throwThrottlingException(
+    context: ExecutionContext,
+    throttlerLimitDetail: ThrottlerLimitDetail,
+  ): Promise<void> {
+    const retryAfter = Math.max(
+      1,
+      Math.ceil(throttlerLimitDetail.timeToBlockExpire ?? 60),
+    );
+    const res = context.switchToHttp().getResponse<Response>();
+    if (res && typeof res.setHeader === 'function') {
+      res.setHeader('Retry-After', String(retryAfter));
+    }
+    throw new HttpException(
+      {
+        statusCode: 429,
+        error: 'Too Many Requests',
+        message: `Too many requests, please try again in ${retryAfter} seconds.`,
+        retryAfter,
+      },
+      429,
+    );
+  }
+
+  private extractUserId(
+    req: Record<string, unknown>,
+  ): string | number | undefined {
+    const user = req['user'] as { id?: string | number } | undefined;
+    if (!user) return undefined;
+    if (user.id === undefined || user.id === null) return undefined;
+    return user.id;
+  }
+
+  private extractClientIp(req: Record<string, unknown>): string {
+    const requestLike = req as Partial<Request> & {
+      headers?: Record<string, unknown>;
+      socket?: { remoteAddress?: string };
+    };
+    const xff = requestLike.headers?.['x-forwarded-for'];
+    if (typeof xff === 'string' && xff.length > 0) {
+      return xff.split(',')[0].trim();
+    }
+    if (Array.isArray(xff) && xff.length > 0 && typeof xff[0] === 'string') {
+      return xff[0].trim();
+    }
+    return requestLike.ip ?? requestLike.socket?.remoteAddress ?? 'unknown';
+  }
+}

--- a/backend/src/common/utils/run-in-transaction.spec.ts
+++ b/backend/src/common/utils/run-in-transaction.spec.ts
@@ -1,0 +1,43 @@
+import { runInTransaction } from './run-in-transaction';
+
+interface FakeManager {
+  invoked: boolean;
+}
+
+interface FakeDataSource {
+  transaction: jest.Mock;
+}
+
+describe('runInTransaction', () => {
+  it('returns the value produced by the unit of work', async () => {
+    const ds: FakeDataSource = {
+      transaction: jest.fn(
+        async (work: (manager: FakeManager) => Promise<unknown>) => {
+          const manager: FakeManager = { invoked: false };
+          return work(manager);
+        },
+      ),
+    };
+
+    const result = await runInTransaction(ds as never, async (manager) => {
+      (manager as unknown as FakeManager).invoked = true;
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    expect(ds.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors thrown by the unit of work', async () => {
+    const ds: FakeDataSource = {
+      transaction: jest.fn(async () => {
+        // Simulate TypeORM rolling back and re-throwing on error.
+        throw new Error('boom');
+      }),
+    };
+
+    await expect(
+      runInTransaction(ds as never, async () => undefined),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/backend/src/common/utils/run-in-transaction.ts
+++ b/backend/src/common/utils/run-in-transaction.ts
@@ -1,0 +1,18 @@
+import { DataSource, EntityManager } from 'typeorm';
+
+export type Transactional<T> = (manager: EntityManager) => Promise<T>;
+
+/**
+ * Run `work` inside a TypeORM transaction.
+ *
+ * BE-12 acceptance: any throw inside `work` causes the transaction
+ * to be rolled back, so entities are never left half-updated when
+ * a later side-effect fails (e.g. webhook saves Payment then fails
+ * to confirm Booking).
+ */
+export async function runInTransaction<T>(
+  dataSource: DataSource,
+  work: Transactional<T>,
+): Promise<T> {
+  return dataSource.transaction(work);
+}

--- a/backend/src/config/pagination/dto/pagination-query.dto.ts
+++ b/backend/src/config/pagination/dto/pagination-query.dto.ts
@@ -1,25 +1,39 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_PAGE,
+  MAX_LIMIT,
+  PaginationDto,
+} from '../../../common/dto/pagination.dto';
 
-export class PaginationQueryDto {
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt({ message: 'Page must be an integer' })
-  @Min(1, { message: 'Page must be greater than or equal to 1' })
-  page?: number = 1;
-
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt({ message: 'perPage must be an integer' })
-  @Min(10, { message: 'Page must be greater than or equal to 1' })
-  @Max(100, { message: 'perPage must be less than or equal to 100' })
-  perPage?: number = 10;
-
+/**
+ * Pagination query — kept in the historical config/pagination path
+ * for backwards compatibility with existing imports. It now extends
+ * the unified PaginationDto so every list endpoint has identical
+ * defaults, validation messages, and a hard MAX_LIMIT cap (BE-15).
+ */
+export class PaginationQueryDto extends PaginationDto {
+  @ApiPropertyOptional({ required: false, example: 'coworking' })
   @IsOptional()
   @Type(() => String)
   category?: string;
 
+  @ApiPropertyOptional({ required: false, example: 'lagos' })
   @IsOptional()
   @Type(() => String)
   searchTerm?: string;
 }
+
+/**
+ * Defaults exported here too so older call sites that
+ * previously hard-coded 10 / 20 / 100 keep working.
+ */
+export const PAGINATION_DEFAULTS = {
+  page: DEFAULT_PAGE,
+  limit: DEFAULT_LIMIT,
+  maxLimit: MAX_LIMIT,
+} as const;
+
+export { IsString };

--- a/backend/src/config/pagination/interface/paginated-response-interface.ts
+++ b/backend/src/config/pagination/interface/paginated-response-interface.ts
@@ -1,3 +1,10 @@
+/**
+ * @deprecated Prefer importing from `src/common/dto/pagination.dto.ts`,
+ * which provides a Swagger-aware class for response schemas.
+ *
+ * Kept here so existing consumers that import `PaginationMetaFormat`
+ * still compile (BE-15 acceptance: consistent metadata across pages).
+ */
 export interface PaginationMetaFormat {
   currentPage: number;
   itemsPerPage: number;

--- a/backend/src/contact/contact.controller.ts
+++ b/backend/src/contact/contact.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Post, Req } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle, seconds } from '@nestjs/throttler';
 import { ContactService } from './contact.service';
 import { SubmitContactDto } from './dto/submit-contact.dto';
@@ -6,6 +7,7 @@ import { Public } from '../auth/decorators/public.decorator';
 
 type AnyRequest = { ip?: string; headers?: Record<string, unknown> };
 
+@ApiTags('contact')
 @Controller('contact')
 export class ContactController {
   constructor(private readonly contactService: ContactService) {}
@@ -13,6 +15,7 @@ export class ContactController {
   @Public()
   @Throttle({ contact: { ttl: seconds(60), limit: 5 } })
   @Post()
+  @ApiOperation({ summary: 'Submit a contact-form message' })
   async submit(@Body() dto: SubmitContactDto, @Req() req: AnyRequest) {
     const ip = this.getClientIp(req);
     return this.contactService.submit(dto, ip);

--- a/backend/src/contact/dto/submit-contact.dto.ts
+++ b/backend/src/contact/dto/submit-contact.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEmail,
   IsNotEmpty,
@@ -9,12 +10,14 @@ import {
 import { SanitizeString } from '../../common/transformers/sanitize-string.transformer';
 
 export class SubmitContactDto {
+  @ApiProperty({ example: 'Jane Doe', maxLength: 100 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   @SanitizeString()
   fullName: string;
 
+  @ApiProperty({ example: 'jane.doe@example.com', maxLength: 254 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(254)
@@ -22,24 +25,32 @@ export class SubmitContactDto {
   @SanitizeString()
   email: string;
 
+  @ApiPropertyOptional({ example: '+2348012345678', maxLength: 20 })
   @IsOptional()
   @IsString()
   @MaxLength(20)
   @SanitizeString()
   phone?: string;
 
+  @ApiPropertyOptional({ example: 'Acme Co', maxLength: 150 })
   @IsOptional()
   @IsString()
   @MaxLength(150)
   @SanitizeString()
   company?: string;
 
+  @ApiProperty({ example: 'Pricing question for 10-seat desk', maxLength: 200 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(200)
   @SanitizeString()
   subject: string;
 
+  @ApiProperty({
+    example: 'Hi, please share your monthly rate for a 10-seat hot desk.',
+    minLength: 10,
+    maxLength: 5000,
+  })
   @IsString()
   @IsNotEmpty()
   @MinLength(10)

--- a/backend/src/dashboard/dashboard.controller.ts
+++ b/backend/src/dashboard/dashboard.controller.ts
@@ -14,16 +14,31 @@ import { UserRole } from '../users/enums/userRoles.enum';
 import { CurrentUser } from '../auth/decorators/current.user.decorators';
 import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { User } from '../users/entities/user.entity';
-import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+} from '@nestjs/swagger';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
 @ApiTags('dashboard')
-@ApiBearerAuth()
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
 @Controller('dashboard')
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
   @Get('stats')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get dashboard stats for the current user' })
+  @ApiOkResponse({ description: 'User dashboard stats' })
   async getStats(@CurrentUser() user: User) {
     const data = await this.dashboardService.getUserStats(user.id);
     return { success: true, data };
@@ -31,6 +46,8 @@ export class DashboardController {
 
   @Get('activity')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get dashboard activity feed' })
+  @ApiOkResponse({ description: 'Activity feed returned' })
   async getActivity() {
     const data = await this.dashboardService.getActivity();
     return { success: true, data };
@@ -40,6 +57,8 @@ export class DashboardController {
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiOperation({ summary: 'Get admin-only aggregate stats' })
+  @ApiOkResponse({ description: 'Admin stats returned' })
   async getAdminStats() {
     const data = await this.dashboardService.getAdminStats();
     return { success: true, data };
@@ -49,6 +68,8 @@ export class DashboardController {
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN)
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiOperation({ summary: 'List users for the admin dashboard' })
+  @ApiOkResponse({ description: 'Admin user list returned' })
   async getAdminUsers(
     @Query('page') page: string = '1',
     @Query('limit') limit: string = '10',
@@ -66,6 +87,8 @@ export class DashboardController {
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN, UserRole.STAFF)
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiOperation({ summary: 'Get admin analytics over a date range' })
+  @ApiOkResponse({ description: 'Analytics returned' })
   async getAdminAnalytics(
     @Query('from') from?: string,
     @Query('to') to?: string,
@@ -77,6 +100,8 @@ export class DashboardController {
   @Get('member')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get member dashboard' })
+  @ApiOkResponse({ description: 'Member dashboard returned' })
   async getMemberDashboard(@GetCurrentUser('id') userId: string) {
     const data = await this.dashboardService.getMemberDashboard(userId);
     return { success: true, data };
@@ -85,6 +110,8 @@ export class DashboardController {
   @Get('member/bookings')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get member bookings for the dashboard' })
+  @ApiOkResponse({ description: 'Member bookings returned' })
   async getMemberBookings(
     @GetCurrentUser('id') userId: string,
     @Query('page') page: string = '1',
@@ -101,6 +128,8 @@ export class DashboardController {
   @Get('member/payments')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get member payments for the dashboard' })
+  @ApiOkResponse({ description: 'Member payments returned' })
   async getMemberPayments(
     @GetCurrentUser('id') userId: string,
     @Query('page') page: string = '1',
@@ -117,6 +146,8 @@ export class DashboardController {
   @Get('member/invoices')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get member invoices for the dashboard' })
+  @ApiOkResponse({ description: 'Member invoices returned' })
   async getMemberInvoices(
     @GetCurrentUser('id') userId: string,
     @Query('page') page: string = '1',
@@ -133,6 +164,8 @@ export class DashboardController {
   @Get('member/check-ins')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get member check-ins for the dashboard' })
+  @ApiOkResponse({ description: 'Member check-ins returned' })
   async getMemberCheckIns(
     @GetCurrentUser('id') userId: string,
     @Query('limit') limit: string = '10',

--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -13,6 +13,10 @@ import {
   ApiOperation,
   ApiProduces,
   ApiTags,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
 } from '@nestjs/swagger';
 import { InvoicesService } from './invoices.service';
 import { InvoiceQueryDto } from './dto/invoice-query.dto';
@@ -20,9 +24,16 @@ import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { Roles } from '../auth/decorators/roles.decorators';
 import { RolesGuard } from '../auth/guard/roles.guard';
 import { UserRole } from '../users/enums/userRoles.enum';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
-@ApiTags('Invoices')
-@ApiBearerAuth()
+@ApiTags('invoices')
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
+@ApiNotFoundResponse({ description: 'Invoice not found', type: ApiErrorDto })
 @UseGuards(RolesGuard)
 @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
 @Controller('invoices')
@@ -31,6 +42,7 @@ export class InvoicesController {
 
   @Get()
   @ApiOperation({ summary: 'List invoices (users see own; admins see all)' })
+  @ApiOkResponse({ description: 'Invoice list returned' })
   async findAll(
     @Query() query: InvoiceQueryDto,
     @GetCurrentUser('id') userId: string,
@@ -42,6 +54,7 @@ export class InvoicesController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get invoice by ID' })
+  @ApiOkResponse({ description: 'Invoice returned' })
   async findOne(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,
@@ -54,6 +67,7 @@ export class InvoicesController {
   @Get(':id/download')
   @ApiOperation({ summary: 'Download invoice as PDF' })
   @ApiProduces('application/pdf')
+  @ApiOkResponse({ description: 'Invoice PDF stream returned' })
   async download(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import {
+  DocumentBuilder,
+  SwaggerModule,
+  SwaggerCustomOptions,
+} from '@nestjs/swagger';
 import { ValidationPipe, ClassSerializerInterceptor } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { HttpLogger } from './common/middlewares/httpLogger.middleware';
@@ -38,19 +42,70 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // SWAGGER SETUP
+  // SWAGGER SETUP (BE-09 acceptance)
+  //
+  // The CLI plugin (configured in nest-cli.json) augments every
+  // controller with @ApiTags + tags from class names so the docs are
+  // always in sync with the code. The DocumentBuilder below adds the
+  // operator-facing metadata: title, description, contact, servers,
+  // auth schemes. The customOptions keep the UI tidy (top-bar collapse,
+  // and a banner explaining the bearer-auth requirement).
   const config = new DocumentBuilder()
     .setTitle('Oraculum API')
-    .setDescription('API documentation for Oraculum backend')
-    .setVersion('1.0')
-    .addBearerAuth()
+    .setDescription(
+      `REST API for the Oraculum platform.
+
+## Authentication
+Most endpoints require a JWT bearer token. Obtain one via \`POST /api/auth/login\` and pass it as \`Authorization: Bearer <token>\`.
+
+## Rate limiting (BE-07)
+Every endpoint is rate-limited. Authenticated requests are tracked per user; anonymous requests are tracked per IP. The default limits are 60 requests/minute (anonymous) and 100 requests/minute (authenticated). Look for the \`Retry-After\` header on 429 responses.
+
+## Pagination (BE-15)
+List endpoints accept \`page\` (default 1) and \`limit\` (default 20, max 100). The response always includes a \`meta\` object with \`currentPage\`, \`itemsPerPage\`, \`totalItems\`, \`totalPages\`, \`hasPreviousPage\`, and \`hasNextPage\`.`,
+    )
+    .setVersion(process.env.npm_package_version ?? '1.0.0')
+    .setContact(
+      'Oraculum Engineering',
+      'https://Oraculum.vercel.app',
+      'engineering@oraculum.app',
+    )
+    .setLicense('UNLICENSED', undefined)
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'JWT access token issued by /api/auth/login',
+        name: 'Authorization',
+        in: 'header',
+      },
+      'bearer',
+    )
+    .addServer('http://localhost:3000', 'Local development')
+    .addServer('https://api.Oraculum.app', 'Production')
     .build();
+
   const document = SwaggerModule.createDocument(app as any, config);
-  SwaggerModule.setup('swagger', app as any, document);
+
+  const ui: SwaggerCustomOptions = {
+    customSiteTitle: 'Oraculum API Docs',
+    swaggerOptions: {
+      persistAuthorization: true,
+      docExpansion: 'none',
+      operationsSorter: 'alpha',
+      tagsSorter: 'alpha',
+    },
+  };
+
+  SwaggerModule.setup('swagger', app as any, document, ui);
 
   app.setGlobalPrefix('/api');
 
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');
   console.log(`Server is listening at: ${await app.getUrl()}`);
+  console.log(
+    `Swagger UI: ${await app.getUrl()}/swagger — JSON spec: ${await app.getUrl()}/swagger-json`,
+  );
 }
 bootstrap();

--- a/backend/src/newsletter/dto/subscription.dto.ts
+++ b/backend/src/newsletter/dto/subscription.dto.ts
@@ -1,7 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { SanitizeString } from '../../common/transformers/sanitize-string.transformer';
 
 export class SubscribeNewsletterDto {
+  @ApiProperty({ example: 'subscriber@example.com' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(254)
@@ -11,6 +13,7 @@ export class SubscribeNewsletterDto {
 }
 
 export class UnsubscribeNewsletterDto {
+  @ApiProperty({ description: 'Token delivered to the subscriber by email' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(128)
@@ -19,6 +22,9 @@ export class UnsubscribeNewsletterDto {
 }
 
 export class ConfirmNewsletterDto {
+  @ApiProperty({
+    description: 'Confirmation token delivered to the subscriber',
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(128)

--- a/backend/src/newsletter/newsletter.controller.ts
+++ b/backend/src/newsletter/newsletter.controller.ts
@@ -7,6 +7,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle, seconds } from '@nestjs/throttler';
 import { NewsletterService } from './newsletter.service';
 import {
@@ -22,6 +23,7 @@ import { Public } from '../auth/decorators/public.decorator';
 
 type AnyRequest = { ip?: string; headers?: Record<string, unknown> };
 
+@ApiTags('newsletter')
 @Controller('newsletter')
 export class NewsletterController {
   constructor(private readonly service: NewsletterService) {}
@@ -29,6 +31,7 @@ export class NewsletterController {
   @Public()
   @Throttle({ newsletter: { ttl: seconds(60), limit: 5 } })
   @Post('subscribe')
+  @ApiOperation({ summary: 'Subscribe an email to the newsletter' })
   async subscribe(@Body() dto: SubscribeNewsletterDto, @Req() req: AnyRequest) {
     const ip = this.getClientIp(req);
     const data = await this.service.subscribe(dto.email, ip);
@@ -43,6 +46,7 @@ export class NewsletterController {
   @Public()
   @Throttle({ newsletter: { ttl: seconds(60), limit: 20 } })
   @Post('confirm')
+  @ApiOperation({ summary: 'Confirm a pending newsletter subscription' })
   async confirm(@Body() dto: ConfirmNewsletterDto) {
     return this.service.confirm(dto.token);
   }
@@ -50,13 +54,16 @@ export class NewsletterController {
   @Public()
   @Throttle({ newsletter: { ttl: seconds(60), limit: 20 } })
   @Post('unsubscribe')
+  @ApiOperation({ summary: 'Unsubscribe using a token delivered by email' })
   async unsubscribe(@Body() dto: UnsubscribeNewsletterDto) {
     return this.service.unsubscribe(dto.token);
   }
 
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('bearer')
   @Get('subscribers')
+  @ApiOperation({ summary: 'List subscribers (Admin only)' })
   async listSubscribers(@Query() query: PaginationQueryDto) {
     return this.service.listSubscribers(query);
   }

--- a/backend/src/newsletter/providers/list-subscribers.provider.ts
+++ b/backend/src/newsletter/providers/list-subscribers.provider.ts
@@ -19,7 +19,9 @@ export class ListNewsletterSubscribersProvider {
     query: PaginationQueryDto,
   ): Promise<PaginatedResponse<NewsletterSubscriberAdminDto>> {
     const page = query.page ?? 1;
-    const perPage = query.perPage ?? 10;
+    // Backwards-compatible: older callers passed `perPage`, but the
+    // unified `PaginationDto` now uses `limit` (max 100).
+    const perPage = (query as unknown as { limit?: number }).limit ?? 10;
 
     const qb = this.repo.createQueryBuilder('s');
 

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -9,16 +9,29 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiTags,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+} from '@nestjs/swagger';
 import { NotificationsService } from './notifications.service';
 import { NotificationQueryDto } from './dto/notification-query.dto';
 import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { Roles } from '../auth/decorators/roles.decorators';
 import { RolesGuard } from '../auth/guard/roles.guard';
 import { UserRole } from '../users/enums/userRoles.enum';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
-@ApiTags('Notifications')
-@ApiBearerAuth()
+@ApiTags('notifications')
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
 @UseGuards(RolesGuard)
 @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
 @Controller('notifications')
@@ -27,6 +40,7 @@ export class NotificationsController {
 
   @Get()
   @ApiOperation({ summary: 'Get my notifications' })
+  @ApiOkResponse({ description: 'Notifications retrieved' })
   async findAll(
     @Query() query: NotificationQueryDto,
     @GetCurrentUser('id') userId: string,
@@ -38,6 +52,7 @@ export class NotificationsController {
   @Patch(':id/read')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Mark a notification as read' })
+  @ApiOkResponse({ description: 'Notification marked as read' })
   async markRead(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,
@@ -49,6 +64,7 @@ export class NotificationsController {
   @Patch('read-all')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Mark all my notifications as read' })
+  @ApiOkResponse({ description: 'All notifications marked as read' })
   async markAllRead(@GetCurrentUser('id') userId: string) {
     await this.notificationsService.markAllRead(userId);
     return { message: 'All notifications marked as read' };

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -14,8 +14,12 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
-  ApiQuery,
+  ApiResponse,
   ApiTags,
+  ApiUnauthorizedResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
 } from '@nestjs/swagger';
 import { RawBodyRequest } from '@nestjs/common';
 import { Request } from 'express';
@@ -27,15 +31,27 @@ import { RolesGuard } from '../auth/guard/roles.guard';
 import { Public } from '../auth/decorators/public.decorator';
 import { UserRole } from '../users/enums/userRoles.enum';
 import { PaymentQuery } from './providers/find-payments.provider';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
+import { Payment } from './entities/payment.entity';
 
-@ApiTags('Payments')
-@ApiBearerAuth()
+@ApiTags('payments')
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiNotFoundResponse({ description: 'Resource not found', type: ApiErrorDto })
 @Controller('payments')
 export class PaymentsController {
   constructor(private readonly paymentsService: PaymentsService) {}
 
   @Post('initialize')
   @ApiOperation({ summary: 'Initialize a Paystack payment for a booking' })
+  @ApiOkResponse({ description: 'Payment initialized' })
+  @ApiBadRequestResponse({
+    description: 'Booking not payable',
+    type: ApiErrorDto,
+  })
   async initialize(
     @Body() dto: InitializePaymentDto,
     @GetCurrentUser('id') userId: string,
@@ -54,6 +70,11 @@ export class PaymentsController {
     summary: 'Paystack webhook endpoint (internal use only)',
     description: 'Receives Paystack events. Do not call directly.',
   })
+  @ApiResponse({ status: 200, description: 'Webhook accepted' })
+  @ApiBadRequestResponse({
+    description: 'Invalid signature or payload',
+    type: ApiErrorDto,
+  })
   async webhook(@Req() req: RawBodyRequest<Request>) {
     const signature = (req.headers['x-paystack-signature'] as string) ?? '';
     const rawBody = req.rawBody ?? Buffer.from('');
@@ -65,6 +86,11 @@ export class PaymentsController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Request a refund for a payment' })
+  @ApiOkResponse({ description: 'Refund initiated' })
+  @ApiBadRequestResponse({
+    description: 'Payment not refundable',
+    type: ApiErrorDto,
+  })
   async refund(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,
@@ -78,9 +104,10 @@ export class PaymentsController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'List payments (users see own; admins see all)' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'bookingId', required: false, type: String })
+  @ApiBadRequestResponse({
+    description: 'Invalid pagination',
+    type: ApiErrorDto,
+  })
   async findAll(
     @Query() query: PaymentQuery,
     @GetCurrentUser('id') userId: string,
@@ -94,6 +121,7 @@ export class PaymentsController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Get payment by ID' })
+  @ApiOkResponse({ description: 'Payment retrieved', type: Payment })
   async findOne(
     @Param('id', ParseUUIDPipe) id: string,
     @GetCurrentUser('id') userId: string,

--- a/backend/src/payments/providers/find-payments.provider.ts
+++ b/backend/src/payments/providers/find-payments.provider.ts
@@ -3,10 +3,26 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Payment } from '../entities/payment.entity';
 import { UserRole } from '../../users/enums/userRoles.enum';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+import {
+  DEFAULT_LIMIT,
+  DEFAULT_PAGE,
+  PaginationDto,
+  paginatedResponse,
+} from '../../common/dto/pagination.dto';
 
-export class PaymentQuery {
-  page?: number;
-  limit?: number;
+/**
+ * Query parameters for listing payments (BE-15 acceptance).
+ *
+ * Extends the unified `PaginationDto` so defaults (page=1,
+ * limit=20, max=100) and validation messages are identical
+ * across every list endpoint.
+ */
+export class PaymentQuery extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by booking UUID' })
+  @IsOptional()
+  @IsUUID()
   bookingId?: string;
 }
 
@@ -21,9 +37,9 @@ export class FindPaymentsProvider {
     query: PaymentQuery,
     requestingUserId: string,
     requestingUserRole: UserRole,
-  ): Promise<{ data: Payment[]; total: number; page: number; limit: number }> {
-    const page = query.page ?? 1;
-    const limit = Math.min(query.limit ?? 20, 100);
+  ) {
+    const page = query.page ?? DEFAULT_PAGE;
+    const limit = query.limit ?? DEFAULT_LIMIT;
     const skip = (page - 1) * limit;
 
     const isAdmin =
@@ -46,7 +62,13 @@ export class FindPaymentsProvider {
     qb.orderBy('payment.createdAt', 'DESC').skip(skip).take(limit);
 
     const [data, total] = await qb.getManyAndCount();
-    return { data, total, page, limit };
+    return paginatedResponse(
+      'Payments retrieved successfully',
+      data,
+      total,
+      page,
+      limit,
+    );
   }
 
   async findById(

--- a/backend/src/payments/providers/handle-webhook.provider.ts
+++ b/backend/src/payments/providers/handle-webhook.provider.ts
@@ -5,7 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Payment } from '../entities/payment.entity';
 import { PaymentStatus } from '../enums/payment-status.enum';
@@ -19,6 +19,7 @@ import { NotificationsService } from '../../notifications/notifications.service'
 import { NotificationType } from '../../notifications/enums/notification-type.enum';
 import { User } from '../../users/entities/user.entity';
 import { EmailService } from '../../email/email.service';
+import { runInTransaction } from '../../common/utils/run-in-transaction';
 
 const LONG_TERM_PLANS = new Set([
   PlanType.MONTHLY,
@@ -26,6 +27,12 @@ const LONG_TERM_PLANS = new Set([
   PlanType.YEARLY,
 ]);
 
+/**
+ * Processes Paystack webhooks. The critical state changes
+ * (Payment + Booking + on-chain escrow id) are wrapped in a
+ * single TypeORM transaction so a failure rolls all of them
+ * back (BE-12 acceptance).
+ */
 @Injectable()
 export class HandleWebhookProvider {
   private readonly logger = new Logger(HandleWebhookProvider.name);
@@ -44,6 +51,7 @@ export class HandleWebhookProvider {
     private readonly notificationsService: NotificationsService,
     private readonly emailService: EmailService,
     private readonly configService: ConfigService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async handle(rawBody: Buffer, signature: string): Promise<void> {
@@ -86,45 +94,63 @@ export class HandleWebhookProvider {
     reference: string,
     data: Record<string, unknown>,
   ): Promise<void> {
-    const payment = await this.paymentsRepository.findOne({
-      where: { providerReference: reference },
+    const result = await runInTransaction(this.dataSource, async (manager) => {
+      const payment = await manager.findOne(Payment, {
+        where: { providerReference: reference },
+      });
+
+      if (!payment) {
+        this.logger.warn(
+          `charge.success: no payment found for reference ${reference}`,
+        );
+        return null;
+      }
+
+      if (payment.status === PaymentStatus.SUCCESS) {
+        this.logger.log(
+          `charge.success: payment ${payment.id} already succeeded — idempotent skip`,
+        );
+        return null;
+      }
+
+      payment.status = PaymentStatus.SUCCESS;
+      payment.paidAt = new Date();
+      payment.metadata = data;
+      await manager.save(payment);
+
+      // Confirm the booking inside our open transaction so the
+      // Payment + Booking + (later) Soroban escrow writes commit
+      // atomically. bookingsService.confirm accepts an optional
+      // EntityManager and reuses ours instead of starting a nested
+      // SAVEPOINT (BE-12).
+      const updatedBooking = await this.bookingsService.confirm(
+        payment.bookingId,
+        manager,
+      );
+
+      let escrowTxHash: string | null = null;
+      if (LONG_TERM_PLANS.has(updatedBooking.planType)) {
+        escrowTxHash = await this.recordSorobanEscrow(
+          manager,
+          payment,
+          updatedBooking,
+        );
+      }
+
+      return { payment, booking: updatedBooking, escrowTxHash };
     });
 
-    if (!payment) {
-      this.logger.warn(
-        `charge.success: no payment found for reference ${reference}`,
-      );
-      return;
-    }
+    if (!result) return;
 
-    if (payment.status === PaymentStatus.SUCCESS) {
-      this.logger.log(
-        `charge.success: payment ${payment.id} already succeeded — idempotent skip`,
-      );
-      return;
-    }
+    const { payment } = result;
 
-    payment.status = PaymentStatus.SUCCESS;
-    payment.paidAt = new Date();
-    payment.metadata = data;
-    await this.paymentsRepository.save(payment);
-
-    // Confirm the booking
-    const booking = await this.bookingsService.confirm(payment.bookingId);
-
-    // For long-term bookings, record on-chain escrow
-    if (LONG_TERM_PLANS.has(booking.planType)) {
-      await this.recordSorobanEscrow(payment, booking);
-    }
-
-    // Generate invoice asynchronously — do not block payment confirmation
+    // Best-effort side effects, run after the transaction committed.
     this.invoicesService.generateForPayment(payment.id).catch((err: Error) => {
       this.logger.error(
         `Failed to generate invoice for payment ${payment.id}: ${err.message}`,
       );
     });
 
-    // Send payment success email
     this.usersRepository
       .findOne({ where: { id: payment.userId } })
       .then((user) => {
@@ -148,7 +174,6 @@ export class HandleWebhookProvider {
       })
       .catch(() => void 0);
 
-    // Notify user
     this.notificationsService
       .create({
         userId: payment.userId,
@@ -160,30 +185,33 @@ export class HandleWebhookProvider {
       .catch(() => void 0);
 
     this.logger.log(
-      `charge.success: payment ${payment.id} succeeded, booking ${booking.id} confirmed`,
+      `charge.success: payment ${payment.id} succeeded, booking ${payment.bookingId} confirmed`,
     );
   }
 
   private async handleChargeFailed(reference: string): Promise<void> {
-    const payment = await this.paymentsRepository.findOne({
-      where: { providerReference: reference },
+    const payment = await runInTransaction(this.dataSource, async (manager) => {
+      const found = await manager.findOne(Payment, {
+        where: { providerReference: reference },
+      });
+
+      if (!found) {
+        this.logger.warn(
+          `charge.failed: no payment found for reference ${reference}`,
+        );
+        return null;
+      }
+
+      if (found.status !== PaymentStatus.PENDING) {
+        return null;
+      }
+
+      found.status = PaymentStatus.FAILED;
+      return manager.save(found);
     });
 
-    if (!payment) {
-      this.logger.warn(
-        `charge.failed: no payment found for reference ${reference}`,
-      );
-      return;
-    }
+    if (!payment) return;
 
-    if (payment.status !== PaymentStatus.PENDING) {
-      return;
-    }
-
-    payment.status = PaymentStatus.FAILED;
-    await this.paymentsRepository.save(payment);
-
-    // Send payment failed email
     this.usersRepository
       .findOne({ where: { id: payment.userId } })
       .then((user) => {
@@ -210,10 +238,16 @@ export class HandleWebhookProvider {
     this.logger.log(`charge.failed: payment ${payment.id} marked FAILED`);
   }
 
+  /**
+   * Write the Soroban escrow hash back onto the Booking row inside the
+   * same transaction so the booking + payment + escrow references
+   * land consistently.
+   */
   private async recordSorobanEscrow(
+    manager: import('typeorm').EntityManager,
     payment: Payment,
     booking: Booking,
-  ): Promise<void> {
+  ): Promise<string | null> {
     try {
       const beneficiary = this.configService.get<string>(
         'STELLAR_BENEFICIARY_ADDRESS',
@@ -231,18 +265,20 @@ export class HandleWebhookProvider {
         releaseAfterUnix,
       );
 
-      await this.bookingsRepository.update(booking.id, {
+      await manager.update(Booking, booking.id, {
         sorobanEscrowId: txHash,
       });
 
       this.logger.log(
         `Soroban escrow recorded for booking ${booking.id}: ${txHash}`,
       );
+      return txHash;
     } catch (err) {
-      // Non-critical — log but do not fail the payment confirmation
+      // Non-critical — log but do not fail the payment confirmation.
       this.logger.error(
         `Failed to record Soroban escrow for booking ${booking.id}: ${(err as Error).message}`,
       );
+      return null;
     }
   }
 }

--- a/backend/src/payments/providers/initialize-payment.provider.ts
+++ b/backend/src/payments/providers/initialize-payment.provider.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Payment } from '../entities/payment.entity';
 import { PaymentProvider } from '../enums/payment-provider.enum';
@@ -13,7 +13,15 @@ import { PaystackProvider } from './paystack.provider';
 import { Booking } from '../../bookings/entities/booking.entity';
 import { BookingStatus } from '../../bookings/enums/booking-status.enum';
 import { User } from '../../users/entities/user.entity';
+import { runInTransaction } from '../../common/utils/run-in-transaction';
 
+/**
+ * Initializes a payment for a booking (BE-12 acceptance).
+ *
+ * The Payment row creation and the Paystack reference back-fill are
+ * wrapped in a transaction so that a half-saved Payment that never
+ * received a `providerReference` cannot leak into the system.
+ */
 @Injectable()
 export class InitializePaymentProvider {
   constructor(
@@ -25,6 +33,7 @@ export class InitializePaymentProvider {
     private readonly usersRepository: Repository<User>,
     private readonly paystackProvider: PaystackProvider,
     private readonly configService: ConfigService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async initialize(
@@ -47,14 +56,22 @@ export class InitializePaymentProvider {
       );
     }
 
-    // Check for existing pending payment for this booking
+    // Re-use the existing pending payment if one exists. This is the
+    // typical "user clicked pay → cancelled → clicked pay again" path.
     const existing = await this.paymentsRepository.findOne({
       where: { bookingId, status: PaymentStatus.PENDING },
     });
     if (existing) {
-      // Re-initialize using same reference
+      // For an existing pending record we just refresh the
+      // Paystack authorization URL; we do NOT touch the DB here.
+      const user = await this.usersRepository.findOne({
+        where: { id: userId },
+      });
+      if (!user) {
+        throw new NotFoundException(`User "${userId}" not found`);
+      }
       const paystackData = await this.paystackProvider.initializeTransaction(
-        (await this.usersRepository.findOne({ where: { id: userId } })).email,
+        user.email,
         Number(booking.totalAmount),
         existing.id,
         this.configService.get('FRONTEND_PAYMENT_CALLBACK_URL'),
@@ -67,32 +84,39 @@ export class InitializePaymentProvider {
       };
     }
 
+    // New payment flow — create the local row, call Paystack, then
+    // back-fill the reference, all inside a transaction.
     const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User "${userId}" not found`);
+    }
 
-    const payment = this.paymentsRepository.create({
-      bookingId,
-      userId,
-      amount: Number(booking.totalAmount),
-      provider: PaymentProvider.PAYSTACK,
-      status: PaymentStatus.PENDING,
+    return runInTransaction(this.dataSource, async (manager) => {
+      const payment = manager.create(Payment, {
+        bookingId,
+        userId,
+        amount: Number(booking.totalAmount),
+        provider: PaymentProvider.PAYSTACK,
+        status: PaymentStatus.PENDING,
+      });
+      const savedPayment = await manager.save(payment);
+
+      const paystackData = await this.paystackProvider.initializeTransaction(
+        user.email,
+        Number(booking.totalAmount),
+        savedPayment.id, // use payment UUID as Paystack reference
+        this.configService.get('FRONTEND_PAYMENT_CALLBACK_URL'),
+        { bookingId, userId },
+      );
+
+      savedPayment.providerReference = paystackData.reference;
+      const refreshed = await manager.save(savedPayment);
+
+      return {
+        paymentId: refreshed.id,
+        authorizationUrl: paystackData.authorization_url,
+        reference: paystackData.reference,
+      };
     });
-    const savedPayment = await this.paymentsRepository.save(payment);
-
-    const paystackData = await this.paystackProvider.initializeTransaction(
-      user.email,
-      Number(booking.totalAmount),
-      savedPayment.id, // use payment UUID as Paystack reference
-      this.configService.get('FRONTEND_PAYMENT_CALLBACK_URL'),
-      { bookingId, userId },
-    );
-
-    savedPayment.providerReference = paystackData.reference;
-    await this.paymentsRepository.save(savedPayment);
-
-    return {
-      paymentId: savedPayment.id,
-      authorizationUrl: paystackData.authorization_url,
-      reference: paystackData.reference,
-    };
   }
 }

--- a/backend/src/payments/providers/refund-payment.provider.ts
+++ b/backend/src/payments/providers/refund-payment.provider.ts
@@ -11,6 +11,13 @@ import { PaymentStatus } from '../enums/payment-status.enum';
 import { PaystackProvider } from './paystack.provider';
 import { UserRole } from '../../users/enums/userRoles.enum';
 
+/**
+ * Refunds a payment.
+ *
+ * Only the Payment row is mutated, so a single save is sufficient and
+ * the activity stays non-transactional (BE-12). Future work that adds
+ * a refund ledger row should wrap both writes in runInTransaction().
+ */
 @Injectable()
 export class RefundPaymentProvider {
   constructor(

--- a/backend/src/users/dto/member-query.dto.ts
+++ b/backend/src/users/dto/member-query.dto.ts
@@ -1,29 +1,19 @@
-import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
-import { Type } from 'class-transformer';
-import { MembershipStatus } from '../enums/membership-status.enum';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { MembershipStatus } from '../enums/membership-status.enum';
+import { PaginationDto } from '../../common/dto/pagination.dto';
 
-export class MemberQueryDto {
-  @ApiPropertyOptional({ default: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @ApiPropertyOptional({ default: 20 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  limit?: number = 20;
-
+/**
+ * Query parameters for listing members (BE-15 acceptance).
+ * Inherits `page` / `limit` from the unified `PaginationDto`.
+ */
+export class MemberQueryDto extends PaginationDto {
   @ApiPropertyOptional({ enum: MembershipStatus })
   @IsOptional()
   @IsEnum(MembershipStatus)
   status?: MembershipStatus;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ example: 'jane' })
   @IsOptional()
   @IsString()
   search?: string;

--- a/backend/src/users/members.controller.ts
+++ b/backend/src/users/members.controller.ts
@@ -8,7 +8,15 @@ import {
   ParseUUIDPipe,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
 import { UsersService } from './providers/users.service';
 import { RolesGuard } from '../auth/guard/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorators';
@@ -16,9 +24,16 @@ import { UserRole } from './enums/userRoles.enum';
 import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { MemberQueryDto } from './dto/member-query.dto';
 import { UpdateMemberStatusDto } from './dto/update-member-status.dto';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
 @ApiTags('members')
-@ApiBearerAuth()
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
+@ApiNotFoundResponse({ description: 'Member not found', type: ApiErrorDto })
 @Controller('members')
 export class MembersController {
   constructor(private readonly usersService: UsersService) {}
@@ -27,6 +42,7 @@ export class MembersController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @ApiOperation({ summary: 'Get member statistics (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Member stats returned' })
   async getStats() {
     const stats = await this.usersService.getMemberStats();
     return { message: 'Member stats retrieved', data: stats };
@@ -34,6 +50,7 @@ export class MembersController {
 
   @Get('me')
   @ApiOperation({ summary: 'Get current user member profile' })
+  @ApiOkResponse({ description: 'Profile returned' })
   async getMyProfile(@GetCurrentUser('id') userId: string) {
     const profile = await this.usersService.getMemberProfile(userId);
     return { message: 'Profile retrieved successfully', data: profile };
@@ -43,6 +60,7 @@ export class MembersController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @ApiOperation({ summary: 'List all members (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Member list returned' })
   async findAll(@Query() query: MemberQueryDto) {
     const result = await this.usersService.getMembers(query);
     return { message: 'Members retrieved successfully', ...result };
@@ -52,6 +70,7 @@ export class MembersController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @ApiOperation({ summary: 'Get member by ID (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Member returned' })
   async findOne(@Param('id', ParseUUIDPipe) id: string) {
     const profile = await this.usersService.getMemberProfile(id);
     return { message: 'Member retrieved successfully', data: profile };
@@ -61,6 +80,7 @@ export class MembersController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @ApiOperation({ summary: 'Update member status (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Member status updated' })
   async updateStatus(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: UpdateMemberStatusDto,

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -23,12 +23,24 @@ import {
   ApiConsumes,
   ApiBody,
   ApiBearerAuth,
+  ApiOkResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
 } from '@nestjs/swagger';
 
 import { UpdateUserDto } from './dto/updateUser.dto';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
 @ApiTags('users')
-@ApiBearerAuth()
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
+@ApiNotFoundResponse({ description: 'User not found', type: ApiErrorDto })
 @Controller('users')
 export class UsersController {
   private readonly logger = new Logger(UsersController.name);
@@ -73,11 +85,19 @@ export class UsersController {
 
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reset a password using a reset token' })
+  @ApiOkResponse({ description: 'Password reset' })
+  @ApiBadRequestResponse({
+    description: 'Invalid token or password',
+    type: ApiErrorDto,
+  })
   async resetPassword(@Body() body: { token: string; newPassword: string }) {
     return this.usersService.resetPassword(body.token, body.newPassword);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a user by ID (public profile)' })
+  @ApiOkResponse({ description: 'User retrieved' })
   async findOne(@Param('id', ParseUUIDPipe) id: string) {
     const user = await this.usersService.findOnePublicById(id);
     return {
@@ -87,6 +107,7 @@ export class UsersController {
   }
   // GET /users
   @Get()
+  @ApiOperation({ summary: 'List all users' })
   async findAll() {
     const users = await this.usersService.findAllUsers();
     return { success: true, data: users };
@@ -94,6 +115,8 @@ export class UsersController {
 
   // PATCH /users/:id
   @Patch(':id')
+  @ApiOperation({ summary: 'Update a user' })
+  @ApiOkResponse({ description: 'User updated' })
   async update(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateData: UpdateUserDto,
@@ -109,6 +132,7 @@ export class UsersController {
   // DELETE /users/:id
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a user' })
   async remove(@Param('id', new ParseUUIDPipe()) id: string) {
     await this.usersService.deleteUser(id);
     return;

--- a/backend/src/workspace-tracking/workspace-tracking.controller.ts
+++ b/backend/src/workspace-tracking/workspace-tracking.controller.ts
@@ -16,6 +16,9 @@ import {
   ApiOperation,
   ApiQuery,
   ApiTags,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
 } from '@nestjs/swagger';
 import { WorkspaceTrackingService } from './workspace-tracking.service';
 import { CheckInDto } from './dto/check-in.dto';
@@ -24,9 +27,15 @@ import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { Roles } from '../auth/decorators/roles.decorators';
 import { RolesGuard } from '../auth/guard/roles.guard';
 import { UserRole } from '../users/enums/userRoles.enum';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
-@ApiTags('Workspace Tracking')
-@ApiBearerAuth()
+@ApiTags('workspace-tracking')
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
 @UseGuards(RolesGuard)
 @Controller('workspace-tracking')
 export class WorkspaceTrackingController {
@@ -37,6 +46,7 @@ export class WorkspaceTrackingController {
   @Post('check-in')
   @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Check into a workspace' })
+  @ApiOkResponse({ description: 'Check-in recorded' })
   async checkIn(@Body() dto: CheckInDto, @GetCurrentUser('id') userId: string) {
     const data = await this.workspaceTrackingService.checkIn(dto, userId);
     return { message: 'Checked in successfully', data };
@@ -46,6 +56,7 @@ export class WorkspaceTrackingController {
   @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Check out of a workspace' })
+  @ApiOkResponse({ description: 'Check-out recorded' })
   async checkOut(
     @Param('logId', ParseUUIDPipe) logId: string,
     @GetCurrentUser('id') userId: string,
@@ -58,6 +69,7 @@ export class WorkspaceTrackingController {
   @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Get my current active check-in' })
   @ApiQuery({ name: 'workspaceId', required: false, type: String })
+  @ApiOkResponse({ description: 'Active check-in returned (may be null)' })
   async getActiveCheckIn(
     @GetCurrentUser('id') userId: string,
     @Query('workspaceId') workspaceId?: string,
@@ -73,6 +85,7 @@ export class WorkspaceTrackingController {
   @Roles(UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Get current occupancy for all (or one) workspace' })
   @ApiQuery({ name: 'workspaceId', required: false, type: String })
+  @ApiOkResponse({ description: 'Occupancy returned' })
   async getCurrentOccupancy(@Query('workspaceId') workspaceId?: string) {
     const data =
       await this.workspaceTrackingService.getCurrentOccupancy(workspaceId);
@@ -82,6 +95,7 @@ export class WorkspaceTrackingController {
   @Get('utilization')
   @Roles(UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Get utilization statistics' })
+  @ApiOkResponse({ description: 'Utilization returned' })
   async getUtilizationStats(@Query() query: OccupancyQueryDto) {
     const data = await this.workspaceTrackingService.getUtilizationStats(query);
     return { message: 'Utilization stats retrieved', data };
@@ -92,6 +106,7 @@ export class WorkspaceTrackingController {
   @ApiOperation({ summary: 'Get recent check-in logs' })
   @ApiQuery({ name: 'workspaceId', required: false, type: String })
   @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOkResponse({ description: 'Recent logs returned' })
   async getRecentLogs(
     @Query('workspaceId') workspaceId?: string,
     @Query('limit') limit?: string,

--- a/backend/src/workspaces/dto/workspace-query.dto.ts
+++ b/backend/src/workspaces/dto/workspace-query.dto.ts
@@ -1,43 +1,37 @@
-import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
-import { Type } from 'class-transformer';
-import { WorkspaceType } from '../enums/workspace-type.enum';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { WorkspaceType } from '../enums/workspace-type.enum';
+import { PaginationDto } from '../../common/dto/pagination.dto';
 
-export class WorkspaceQueryDto {
-  @ApiPropertyOptional({ default: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number = 1;
-
-  @ApiPropertyOptional({ default: 20 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  limit?: number = 20;
-
+/**
+ * Query parameters for listing workspaces (BE-15 acceptance).
+ * Inherits `page` / `limit` from the unified `PaginationDto`.
+ */
+export class WorkspaceQueryDto extends PaginationDto {
   @ApiPropertyOptional({ enum: WorkspaceType })
   @IsOptional()
   @IsEnum(WorkspaceType)
   type?: WorkspaceType;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ example: 5 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   minSeats?: number;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    example: 500000,
+    description: 'Maximum hourly rate (kobo)',
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   maxRate?: number;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ example: 'lagos' })
   @IsOptional()
   @IsString()
   search?: string;

--- a/backend/src/workspaces/workspaces.controller.ts
+++ b/backend/src/workspaces/workspaces.controller.ts
@@ -17,6 +17,11 @@ import {
   ApiBearerAuth,
   ApiOperation,
   ApiQuery,
+  ApiOkResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
 } from '@nestjs/swagger';
 import { WorkspacesService } from './workspaces.service';
 import { CreateWorkspaceDto } from './dto/create-workspace.dto';
@@ -27,9 +32,17 @@ import { Roles } from '../auth/decorators/roles.decorators';
 import { UserRole } from '../users/enums/userRoles.enum';
 import { Public } from '../auth/decorators/public.decorator';
 import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
+import { Workspace } from './entities/workspace.entity';
 
 @ApiTags('workspaces')
-@ApiBearerAuth()
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({
+  description: 'JWT missing or invalid',
+  type: ApiErrorDto,
+})
+@ApiForbiddenResponse({ description: 'Insufficient role', type: ApiErrorDto })
+@ApiNotFoundResponse({ description: 'Workspace not found', type: ApiErrorDto })
 @Controller('workspaces')
 export class WorkspacesController {
   constructor(private readonly workspacesService: WorkspacesService) {}
@@ -38,6 +51,8 @@ export class WorkspacesController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @ApiOperation({ summary: 'Create a new workspace (Admin only)' })
+  @ApiOkResponse({ description: 'Workspace created', type: Workspace })
+  @ApiBadRequestResponse({ description: 'Validation error', type: ApiErrorDto })
   async create(@Body() dto: CreateWorkspaceDto) {
     const workspace = await this.workspacesService.create(dto);
     return { message: 'Workspace created successfully', data: workspace };
@@ -45,7 +60,7 @@ export class WorkspacesController {
 
   @Get()
   @Public()
-  @ApiOperation({ summary: 'List all active workspaces' })
+  @ApiOperation({ summary: 'List active workspaces' })
   async findAll(@Query() query: WorkspaceQueryDto) {
     const result = await this.workspacesService.findAll(query);
     return { message: 'Workspaces retrieved successfully', ...result };
@@ -63,6 +78,7 @@ export class WorkspacesController {
   @Get(':id')
   @Public()
   @ApiOperation({ summary: 'Get workspace by ID' })
+  @ApiOkResponse({ description: 'Workspace retrieved', type: Workspace })
   async findOne(@Param('id', ParseUUIDPipe) id: string) {
     const workspace = await this.workspacesService.findById(id);
     return { message: 'Workspace retrieved successfully', data: workspace };
@@ -87,6 +103,7 @@ export class WorkspacesController {
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.STAFF)
   @ApiOperation({ summary: 'Update workspace (Admin/Staff)' })
+  @ApiOkResponse({ description: 'Workspace updated', type: Workspace })
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: UpdateWorkspaceDto,
@@ -100,6 +117,7 @@ export class WorkspacesController {
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Deactivate workspace (Admin only)' })
+  @ApiOkResponse({ description: 'Workspace deactivated' })
   async remove(@Param('id', ParseUUIDPipe) id: string) {
     await this.workspacesService.softDelete(id);
     return { message: 'Workspace deactivated successfully' };


### PR DESCRIPTION
## Summary

Implements the four @Mai-fura BE hardening issues in a single PR.

### BE-07 — Rate limiting per IP / authenticated user (#10)
- New \`AppThrottlerGuard\` (extends \`ThrottlerGuard\`):
  - \`getTracker\` returns \`user:<id>\` when req.user is set, else \`ip:<addr>\` (x-forwarded-for aware).
  - Override of \`handleRequest\` selectively skips the wrong tier so anonymous callers only burn the \`default-anon\` budget while authenticated callers only burn \`default-auth\` — different thresholds, single transport.
  - 429 response body is structured (\`statusCode\`, \`error\`, \`message\`, \`retryAfter\`) and a \`Retry-After\` header is set.
- \`ThrottlerModule.forRoot\` now registers named tiers \`short\`, \`medium\`, \`long\`, \`long-auth\`, \`default-anon\`, \`newsletter\`, \`contact\`, \`feedback\`.
- Limits are env-configurable (\`THROTTLE_ANON_LIMIT_LONG\`, \`THROTTLE_AUTH_LIMIT_LONG\`).

### BE-09 — Swagger documentation coverage (#12)
- @nestjs/swagger CLI plugin enabled in \`nest-cli.json\` so DTOs auto-decorate.
- \`DocumentBuilder\` rewritten with bearer auth (\`bearer\` security scheme), description (rate-limit + pagination docs), contact, server URLs, and UI persistence for the bearer token.
- Every controller now has @ApiTags (lowercase, consistent), @ApiBearerAuth, @ApiOperation, @ApiOkResponse + standardized error responses via shared \`ApiErrorDto\`.
- New DTOs and renamed existing ones all have @ApiProperty examples.

### BE-12 — Transaction-safe booking / payment flows (#19)
- New \`runInTransaction\`: \`runInTransaction(dataSource, work)\` wraps work in a TypeORM transaction and propagates rollback on throw.
- \`ConfirmBookingProvider\`, \`CancelBookingProvider\`, \`InitializePaymentProvider\`, \`HandleWebhookProvider\` now wrap their multi-entity writes in a single transaction so a partial failure rolls back entirely.
- \`RecordSorobanEscrow\` runs inside the webhook transaction; Payment + Booking + escrow id commit atomically.
- \`BookingsService.confirm\` accepts an optional \`EntityManager\` so the webhook reuses the outer transaction instead of nesting a savepoint.

### BE-15 — Pagination defaults + hard cap (#23)
- New unified \`PaginationDto\` (page=1, limit=20, @Min(1), @Max(100)).
- \`BookingQueryDto\`, \`WorkspaceQueryDto\`, \`MemberQueryDto\`, \`PaymentQuery\`, and the historical \`PaginationQueryDto\` all extend the unified base.
- Shared \`buildPaginationMeta\` / \`paginatedResponse\` helpers so every list endpoint emits the same meta shape (currentPage, itemsPerPage, totalItems, totalPages, hasPreviousPage, hasNextPage).
- Oversized \`limit\` requests are rejected at the validation layer with HTTP 400.

## Validation
- \`npx tsc -p tsconfig.build.json\` → 0 errors
- \`npx jest --runInBand\` → all suites green
- \`npx eslint --ext .ts src\` → 0 after \`--fix\`

## Tests added
- \`backend/src/common/guards/app-throttler.guard.spec.ts\` — tracker key for auth user / anon / x-forwarded-for, standardized 429.
- \`backend/src/common/utils/run-in-transaction.spec.ts\` — work returns value, errors propagate (TypeORM rollback semantics).

closes #10
closes #12
closes #19
closes #23