### PR TITLE
upload progress

### DIFF
--- a/backend/src/cloudinary/cloudinary.service.spec.ts
+++ b/backend/src/cloudinary/cloudinary.service.spec.ts
@@ -1,0 +1,84 @@
+import { v2 as cloudinary } from 'cloudinary';
+import { CloudinaryService } from './cloudinary.service';
+
+jest.mock('cloudinary', () => ({
+  v2: {
+    uploader: {
+      upload_stream: jest.fn(),
+      destroy: jest.fn(),
+    },
+  },
+}));
+
+describe('CloudinaryService', () => {
+  const mockedUploadStream = cloudinary.uploader.upload_stream as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('emits progress updates during upload and preserves the final state', async () => {
+    const progressUpdates: Array<{ status: string; bytesUploaded: number }> = [];
+
+    mockedUploadStream.mockImplementation((options: unknown, callback: Function) => {
+      const stream = {
+        write: jest.fn(),
+        end: jest.fn(() => callback(null, { secure_url: 'https://example.com/image.jpg' })),
+      };
+      return stream;
+    });
+
+    const service = new CloudinaryService({
+      get: jest.fn().mockReturnValue('profile-pictures'),
+    } as any);
+
+    const result = await service.uploadImage(
+      { buffer: Buffer.from('hello world'), size: 11 } as Express.Multer.File,
+      'profile-pictures',
+      {
+        onProgress: (state) =>
+          progressUpdates.push({
+            status: state.status,
+            bytesUploaded: state.bytesUploaded,
+          }),
+      },
+    );
+
+    expect(progressUpdates[0]?.status).toBe('uploading');
+    expect(progressUpdates.at(-1)?.status).toBe('completed');
+    expect(result.progress?.status).toBe('completed');
+    expect(result.progress?.percent).toBe(100);
+  });
+
+  it('marks uploads as interrupted when the stream fails', async () => {
+    const progressUpdates: Array<{ status: string; bytesUploaded: number }> = [];
+
+    mockedUploadStream.mockImplementation((options: unknown, callback: Function) => {
+      const stream = {
+        write: jest.fn(),
+        end: jest.fn(() => callback(new Error('socket disconnected'))),
+      };
+      return stream;
+    });
+
+    const service = new CloudinaryService({
+      get: jest.fn().mockReturnValue('profile-pictures'),
+    } as any);
+
+    await expect(
+      service.uploadImage(
+        { buffer: Buffer.from('hello world'), size: 11 } as Express.Multer.File,
+        'profile-pictures',
+        {
+          onProgress: (state) =>
+            progressUpdates.push({
+              status: state.status,
+              bytesUploaded: state.bytesUploaded,
+            }),
+        },
+      ),
+    ).rejects.toThrow('Upload interrupted');
+
+    expect(progressUpdates.at(-1)?.status).toBe('interrupted');
+  });
+});

--- a/backend/src/workspaces/providers/create-workspace.provider.ts
+++ b/backend/src/workspaces/providers/create-workspace.provider.ts
@@ -21,6 +21,8 @@ export class CreateWorkspaceProvider {
       );
     }
 
+    
+
     const workspace = this.workspacesRepository.create({
       ...dto,
       availableSeats: dto.totalSeats,


### PR DESCRIPTION
 BE-41 — Add upload progress tracking for large media files
Summary: Improve user experience for large uploads by exposing progress and partial-state updates.
Affected files: backend/src/cloudinary, backend/src/common, backend/src/main.ts
Acceptance criteria:
Large uploads expose progress metadata during transfer.
Clients can recover from interrupted uploads gracefully.
Upload state is preserved across retries where feasible.
closes #49


BE-40 — Add signed URL support for Cloudinary-backed asset access
Summary: Improve asset security by issuing temporary signed URLs for protected media access.
Affected files: backend/src/cloudinary, backend/src/common, backend/src/config
Acceptance criteria:
Media links are served with short-lived signed URLs.
Expired links return clear authorization errors.
Signed URL generation is tested for success and failure cases
closes #48 