### PR TITLE
Added the image compression

### DIFF
--- a/backend/src/common/utils/cloudinary-upload-options.util.spec.ts
+++ b/backend/src/common/utils/cloudinary-upload-options.util.spec.ts
@@ -1,0 +1,31 @@
+import { buildCloudinaryUploadOptions } from './cloudinary-upload-options.util';
+
+describe('buildCloudinaryUploadOptions', () => {
+  it('builds responsive image transforms and eager thumbnails', () => {
+    const options = buildCloudinaryUploadOptions({
+      folder: 'profile-pictures',
+      maxWidth: 1200,
+      maxHeight: 1200,
+      quality: 'auto:good',
+      thumbnailWidth: 200,
+      thumbnailHeight: 200,
+    });
+
+    expect(options.folder).toBe('profile-pictures');
+    expect(options.resource_type).toBe('image');
+    expect(options.transformation).toEqual([
+      { width: 1200, height: 1200, crop: 'limit' },
+      { quality: 'auto:good' },
+      { fetch_format: 'auto' },
+    ]);
+    expect(options.eager).toEqual([
+      {
+        width: 200,
+        height: 200,
+        crop: 'fill',
+        quality: 'auto:good',
+        fetch_format: 'auto',
+      },
+    ]);
+  });
+});

--- a/backend/src/common/utils/cloudinary-upload-options.util.ts
+++ b/backend/src/common/utils/cloudinary-upload-options.util.ts
@@ -1,0 +1,40 @@
+export interface CloudinaryUploadOptions {
+  folder?: string;
+  resourceType?: 'image' | 'video' | 'raw' | 'auto';
+  maxWidth?: number;
+  maxHeight?: number;
+  quality?: string;
+  thumbnailWidth?: number;
+  thumbnailHeight?: number;
+}
+
+export function buildCloudinaryUploadOptions({
+  folder,
+  resourceType = 'image',
+  maxWidth = 1200,
+  maxHeight = 1200,
+  quality = 'auto:good',
+  thumbnailWidth,
+  thumbnailHeight,
+}: CloudinaryUploadOptions = {}) {
+  return {
+    folder: folder || 'uploads',
+    resource_type: resourceType,
+    transformation: [
+      { width: maxWidth, height: maxHeight, crop: 'limit' },
+      { quality },
+      { fetch_format: 'auto' },
+    ],
+    eager: thumbnailWidth || thumbnailHeight
+      ? [
+          {
+            width: thumbnailWidth || maxWidth,
+            height: thumbnailHeight || maxHeight,
+            crop: 'fill',
+            quality,
+            fetch_format: 'auto',
+          },
+        ]
+      : undefined,
+  };
+}


### PR DESCRIPTION
 BE-39 — Add image compression and thumbnail generation for uploads
Summary: Improve responsiveness and storage efficiency by generating optimized image variants.
Affected files: backend/src/cloudinary, backend/src/common, backend/src/config
Acceptance criteria:
Images are resized or compressed automatically on upload.
Thumbnail variants are generated for supported assets.
The process preserves expected image quality.
closes #47
closes #45
