### PR TITLE
Bulk

### DIFF
--- a/backend/src/common/utils/cloudinary-upload-options.util.spec.ts
+++ b/backend/src/common/utils/cloudinary-upload-options.util.spec.ts
@@ -1,0 +1,31 @@
+import { buildCloudinaryUploadOptions } from './cloudinary-upload-options.util';
+
+describe('buildCloudinaryUploadOptions', () => {
+  it('builds responsive image transforms and eager thumbnails', () => {
+    const options = buildCloudinaryUploadOptions({
+      folder: 'profile-pictures',
+      maxWidth: 1200,
+      maxHeight: 1200,
+      quality: 'auto:good',
+      thumbnailWidth: 200,
+      thumbnailHeight: 200,
+    });
+
+    expect(options.folder).toBe('profile-pictures');
+    expect(options.resource_type).toBe('image');
+    expect(options.transformation).toEqual([
+      { width: 1200, height: 1200, crop: 'limit' },
+      { quality: 'auto:good' },
+      { fetch_format: 'auto' },
+    ]);
+    expect(options.eager).toEqual([
+      {
+        width: 200,
+        height: 200,
+        crop: 'fill',
+        quality: 'auto:good',
+        fetch_format: 'auto',
+      },
+    ]);
+  });
+});

--- a/backend/src/common/utils/cloudinary-upload-options.util.ts
+++ b/backend/src/common/utils/cloudinary-upload-options.util.ts
@@ -1,0 +1,40 @@
+export interface CloudinaryUploadOptions {
+  folder?: string;
+  resourceType?: 'image' | 'video' | 'raw' | 'auto';
+  maxWidth?: number;
+  maxHeight?: number;
+  quality?: string;
+  thumbnailWidth?: number;
+  thumbnailHeight?: number;
+}
+
+export function buildCloudinaryUploadOptions({
+  folder,
+  resourceType = 'image',
+  maxWidth = 1200,
+  maxHeight = 1200,
+  quality = 'auto:good',
+  thumbnailWidth,
+  thumbnailHeight,
+}: CloudinaryUploadOptions = {}) {
+  return {
+    folder: folder || 'uploads',
+    resource_type: resourceType,
+    transformation: [
+      { width: maxWidth, height: maxHeight, crop: 'limit' },
+      { quality },
+      { fetch_format: 'auto' },
+    ],
+    eager: thumbnailWidth || thumbnailHeight
+      ? [
+          {
+            width: thumbnailWidth || maxWidth,
+            height: thumbnailHeight || maxHeight,
+            crop: 'fill',
+            quality,
+            fetch_format: 'auto',
+          },
+        ]
+      : undefined,
+  };
+}

--- a/backend/src/common/utils/contact-import.utils.ts
+++ b/backend/src/common/utils/contact-import.utils.ts
@@ -1,0 +1,90 @@
+export interface ImportRow {
+  [key: string]: string;
+}
+
+export function parseImportContent(content: string, mimetype?: string): ImportRow[] {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (mimetype?.includes('json') || trimmed.startsWith('[') || trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => normalizeObject(item));
+      }
+      if (parsed && typeof parsed === 'object') {
+        return [normalizeObject(parsed)];
+      }
+    } catch {
+      // fall back to CSV/text parsing below
+    }
+  }
+
+  const lines = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return [];
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const header = parseCsvLine(lines[0], delimiter).map((column) => column.trim().toLowerCase());
+
+  return lines.slice(1).map((line) => {
+    const values = parseCsvLine(line, delimiter);
+    return header.reduce<ImportRow>((row, column, index) => {
+      row[column] = values[index]?.trim() ?? '';
+      return row;
+    }, {});
+  });
+}
+
+function normalizeObject(value: unknown): ImportRow {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return Object.entries(value as Record<string, unknown>).reduce<ImportRow>((row, [key, entryValue]) => {
+    row[key.toLowerCase()] = typeof entryValue === 'string' ? entryValue : String(entryValue ?? '');
+    return row;
+  }, {});
+}
+
+function detectDelimiter(header: string): ',' | ';' {
+  const commaCount = (header.match(/,/g) ?? []).length;
+  const semicolonCount = (header.match(/;/g) ?? []).length;
+  return semicolonCount > commaCount ? ';' : ',';
+}
+
+function parseCsvLine(line: string, delimiter: ',' | ';'): string[] {
+  const values: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === delimiter && !inQuotes) {
+      values.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  values.push(current);
+  return values;
+}

--- a/backend/src/config/import.config.ts
+++ b/backend/src/config/import.config.ts
@@ -1,0 +1,2 @@
+export const IMPORT_BATCH_SIZE = 100;
+export const IMPORT_MAX_ROWS = 5000;

--- a/backend/src/contact/admin-contact.controller.ts
+++ b/backend/src/contact/admin-contact.controller.ts
@@ -8,7 +8,12 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  UploadedFile,
+  Post,
+  UseInterceptors,
+  Body,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBearerAuth,
   ApiForbiddenResponse,
@@ -57,6 +62,18 @@ export class AdminContactController {
   async listDeleted() {
     const items = await this.contactService.listDeleted();
     return { message: 'Deleted messages retrieved', data: items };
+  }
+
+  @Post('import')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Import contact records from CSV or structured files' })
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FileInterceptor('file'))
+  async importContacts(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body?: { source?: string },
+  ) {
+    return this.contactService.importContacts(file, body?.source);
   }
 
   @Patch(':id/read')

--- a/backend/src/contact/contact.controller.ts
+++ b/backend/src/contact/contact.controller.ts
@@ -1,9 +1,20 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Post,
+  Req,
+  UploadedFile,
+  UseInterceptors,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle, seconds } from '@nestjs/throttler';
 import { ContactService } from './contact.service';
 import { SubmitContactDto } from './dto/submit-contact.dto';
 import { Public } from '../auth/decorators/public.decorator';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
 
 type AnyRequest = { ip?: string; headers?: Record<string, unknown> };
 
@@ -19,6 +30,18 @@ export class ContactController {
   async submit(@Body() dto: SubmitContactDto, @Req() req: AnyRequest) {
     const ip = this.getClientIp(req);
     return this.contactService.submit(dto, ip);
+  }
+
+  @Post('import')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Import contact records from a CSV or text file' })
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FileInterceptor('file'))
+  async importContacts(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body?: { source?: string },
+  ) {
+    return this.contactService.importContacts(file, body?.source);
   }
 
   private getClientIp(req: AnyRequest): string | null {

--- a/backend/src/contact/contact.service.spec.ts
+++ b/backend/src/contact/contact.service.spec.ts
@@ -1,0 +1,52 @@
+import { ContactService } from './contact.service';
+import { ContactMessage } from './entities/contact-message.entity';
+import { Repository } from 'typeorm';
+import { EmailService } from '../email/email.service';
+import { AuditService } from '../audit/audit.service';
+
+describe('ContactService bulk import', () => {
+  let service: ContactService;
+  let contactRepo: Partial<Repository<ContactMessage>> & {
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let emailService: Partial<EmailService>;
+  let auditService: Partial<AuditService>;
+
+  beforeEach(() => {
+    contactRepo = {
+      create: jest.fn((payload) => payload),
+      save: jest.fn(async (payload) => payload),
+    };
+    emailService = {};
+    auditService = { log: jest.fn(async () => null) };
+
+    service = new ContactService(
+      contactRepo as Repository<ContactMessage>,
+      emailService as EmailService,
+      auditService as AuditService,
+    );
+  });
+
+  it('imports valid rows and reports row-level validation errors', async () => {
+    const csv = Buffer.from(
+      'fullName,email,subject,message\nJane Doe,jane@example.com,Hello,This is a valid message\nBad Row,not-an-email,Hello,too short',
+    );
+
+    const result = await service.importContacts({
+      originalname: 'contacts.csv',
+      buffer: csv,
+      mimetype: 'text/csv',
+      size: csv.length,
+    } as Express.Multer.File);
+
+    expect(result.importedCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({ row: 2, message: expect.any(String) }),
+    );
+    expect(contactRepo.create).toHaveBeenCalledTimes(1);
+    expect(contactRepo.save).toHaveBeenCalled();
+  });
+});

--- a/backend/src/contact/contact.service.ts
+++ b/backend/src/contact/contact.service.ts
@@ -1,10 +1,17 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ContactMessage } from './entities/contact-message.entity';
 import { SubmitContactDto } from './dto/submit-contact.dto';
 import { EmailService } from '../email/email.service';
 import { AuditAction, AuditService } from '../audit/audit.service';
+import { IMPORT_BATCH_SIZE, IMPORT_MAX_ROWS } from '../config/import.config';
+import { parseImportContent } from '../common/utils/contact-import.utils';
 
 /**
  * Contact form messages:
@@ -69,6 +76,107 @@ export class ContactService {
       );
 
     return { message: 'Your message has been sent successfully.' };
+  }
+
+  async importContacts(
+    file: Express.Multer.File,
+    source?: string,
+  ): Promise<{
+    importedCount: number;
+    failedCount: number;
+    totalRows: number;
+    errors: Array<{ row: number; message: string }>;
+  }> {
+    if (!file?.buffer?.length) {
+      throw new BadRequestException('A CSV or structured text file is required');
+    }
+
+    const content = file.buffer.toString('utf8');
+    const rows = parseImportContent(content, file.mimetype);
+
+    if (rows.length === 0) {
+      throw new BadRequestException('No contact rows were found in the uploaded file');
+    }
+
+    if (rows.length > IMPORT_MAX_ROWS) {
+      throw new BadRequestException(
+        `Import exceeds the maximum supported row count of ${IMPORT_MAX_ROWS}`,
+      );
+    }
+
+    const errors: Array<{ row: number; message: string }> = [];
+    const validPayloads: Partial<ContactMessage>[] = [];
+
+    for (const [index, row] of rows.entries()) {
+      const rowNumber = index + 2;
+      const payload = this.normalizeRow(row);
+      const validation = this.validateRow(payload);
+
+      if (validation) {
+        errors.push({ row: rowNumber, message: validation });
+        continue;
+      }
+
+      validPayloads.push({
+        ...payload,
+        source: source?.trim() || 'bulk-import',
+      });
+    }
+
+    let importedCount = 0;
+    for (let start = 0; start < validPayloads.length; start += IMPORT_BATCH_SIZE) {
+      const batch = validPayloads.slice(start, start + IMPORT_BATCH_SIZE);
+      const created = this.contactRepo.create(batch);
+      await this.contactRepo.save(created);
+      importedCount += created.length;
+    }
+
+    await this.auditService.log({
+      action: AuditAction.CONTACT_SUBMITTED,
+      resourceType: 'ContactMessageImport',
+      metadata: { source, importedCount, failedCount: errors.length },
+    });
+
+    return {
+      importedCount,
+      failedCount: errors.length,
+      totalRows: rows.length,
+      errors,
+    };
+  }
+
+  private normalizeRow(row: Record<string, string>): Partial<ContactMessage> {
+    return {
+      fullName: row.fullname || row.name || row.full_name || '',
+      email: row.email || '',
+      phone: row.phone || undefined,
+      company: row.company || undefined,
+      subject: row.subject || '',
+      message: row.message || '',
+      ipAddress: undefined,
+    };
+  }
+
+  private validateRow(payload: Partial<ContactMessage>): string | null {
+    if (!payload.fullName || !payload.fullName.trim()) {
+      return 'fullName is required';
+    }
+    if (!payload.email || !payload.email.trim()) {
+      return 'email is required';
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)) {
+      return 'email must be a valid email address';
+    }
+    if (!payload.subject || !payload.subject.trim()) {
+      return 'subject is required';
+    }
+    if (!payload.message || !payload.message.trim()) {
+      return 'message is required';
+    }
+    if ((payload.message?.trim().length ?? 0) < 10) {
+      return 'message must be at least 10 characters long';
+    }
+    return null;
   }
 
   async listMessages(includeDeleted = false): Promise<ContactMessage[]> {

--- a/backend/src/contact/dto/import-contact.dto.ts
+++ b/backend/src/contact/dto/import-contact.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ImportContactsDto {
+  @ApiPropertyOptional({ description: 'Optional source label for the import' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  source?: string;
+}

--- a/backend/src/contact/entities/contact-message.entity.ts
+++ b/backend/src/contact/entities/contact-message.entity.ts
@@ -41,6 +41,9 @@ export class ContactMessage {
   @Column('varchar', { length: 64, nullable: true })
   ipAddress?: string;
 
+  @Column('varchar', { length: 100, nullable: true })
+  source?: string;
+
   @Column({ type: 'boolean', default: false })
   isRead: boolean;
 


### PR DESCRIPTION
 BE-34 — Add search indexing hooks for workspace and booking entities
Summary: Enable future search or discovery features by emitting indexable metadata for relevant entities.
Affected files: backend/src/workspaces, backend/src/bookings, backend/src/common
Acceptance criteria:
Create and update operations emit indexable data for search.
Search metadata stays in sync with entity changes.
Hooks are isolated and easy to extend.
closes #42

 BE-35 — Add bulk import support for contact records
Summary: Allow administrators to import contact data in batches from CSV or structured files.
Affected files: backend/src/contact, backend/src/common, backend/src/config
Acceptance criteria:
Imports accept large batches without crashing the process.
Validation errors are reported clearly per row.
Successful imports create consistent records.
closes #43