### PR TITLE
feat(workspaces): add workspace invitation and acceptance flows

### DIFF
--- a/backend/src/workspaces/workspace-invitations.service.spec.ts
+++ b/backend/src/workspaces/workspace-invitations.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkspaceInvitationsService } from './workspace-invitations.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { EmailService } from '../email/email.service';
+import { ForbiddenException, ConflictException } from '@nestjs/common';
+import { InvitationStatus, WorkspaceRole } from '@prisma/client';
+
+describe('WorkspaceInvitationsService', () => {
+  let service: WorkspaceInvitationsService;
+  let prisma: any;
+  let emailService: any;
+
+  beforeEach(async () => {
+    prisma = {
+      workspaceMember: { findUnique: jest.fn(), findFirst: jest.fn(), create: jest.fn() },
+      workspaceInvitation: { findFirst: jest.fn(), create: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+      user: { findUnique: jest.fn() },
+      $transaction: jest.fn((cb) => cb(prisma)),
+    };
+
+    emailService = {
+      sendWorkspaceInvitationEmail: jest.fn().mockResolvedValue(true),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WorkspaceInvitationsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EmailService, useValue: emailService },
+      ],
+    }).compile();
+
+    service = module.get<WorkspaceInvitationsService>(WorkspaceInvitationsService);
+  });
+
+  it('should successfully create and send invitation when requested by owner', async () => {
+    prisma.workspaceMember.findUnique.mockResolvedValue({
+      role: 'OWNER',
+      workspace: { name: 'Acme Corp' },
+    });
+    prisma.workspaceMember.findFirst.mockResolvedValue(null);
+    prisma.workspaceInvitation.findFirst.mockResolvedValue(null);
+    prisma.workspaceInvitation.create.mockResolvedValue({
+      id: 'inv-1',
+      token: 'uuid-token',
+      email: 'invitee@example.com',
+      status: InvitationStatus.PENDING,
+    });
+
+    const result = await service.createInvitation('ws-1', 'owner-1', {
+      email: 'invitee@example.com',
+    });
+
+    expect(result.id).toBe('inv-1');
+    expect(emailService.sendWorkspaceInvitationEmail).toHaveBeenCalled();
+  });
+
+  it('should reject invitation creation if inviter is non-admin member', async () => {
+    prisma.workspaceMember.findUnique.mockResolvedValue({
+      role: 'MEMBER',
+      workspace: { name: 'Acme Corp' },
+    });
+
+    await expect(
+      service.createInvitation('ws-1', 'member-1', { email: 'invitee@example.com' }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should transition status to ACCEPTED and create workspace membership', async () => {
+    const mockInvitation = {
+      id: 'inv-1',
+      workspaceId: 'ws-1',
+      email: 'invitee@example.com',
+      role: WorkspaceRole.MEMBER,
+      status: InvitationStatus.PENDING,
+      expiresAt: new Date(Date.now() + 10000),
+    };
+
+    prisma.workspaceInvitation.findUnique.mockResolvedValue(mockInvitation);
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', email: 'invitee@example.com' });
+    prisma.workspaceInvitation.update.mockResolvedValue({
+      ...mockInvitation,
+      status: InvitationStatus.ACCEPTED,
+    });
+
+    const res = await service.acceptInvitation('uuid-token', 'user-2');
+
+    expect(prisma.workspaceMember.create).toHaveBeenCalledWith({
+      data: { workspaceId: 'ws-1', userId: 'user-2', role: WorkspaceRole.MEMBER },
+    });
+    expect(res.status).toBe(InvitationStatus.ACCEPTED);
+  });
+});

--- a/backend/src/workspaces/workspace-invitations.service.ts
+++ b/backend/src/workspaces/workspace-invitations.service.ts
@@ -1,0 +1,188 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+  ConflictException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { EmailService } from '../email/email.service';
+import { InvitationStatus, WorkspaceRole } from '@prisma/client';
+
+export interface CreateInvitationDto {
+  email: string;
+  role?: WorkspaceRole;
+}
+
+@Injectable()
+export class WorkspaceInvitationsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  /**
+   * Invites a user to join a workspace by email.
+   */
+  async createInvitation(
+    workspaceId: string,
+    inviterId: string,
+    dto: CreateInvitationDto,
+  ) {
+    // 1. Check workspace existence and inviter authority (Owner or Admin)
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: {
+        workspaceId_userId: { workspaceId, userId: inviterId },
+      },
+      include: { workspace: true },
+    });
+
+    if (!membership || !['OWNER', 'ADMIN'].includes(membership.role)) {
+      throw new ForbiddenException(
+        'Only workspace owners or admins can invite new members.',
+      );
+    }
+
+    const recipientEmail = dto.email.toLowerCase().trim();
+
+    // 2. Check if user is already a member
+    const existingMember = await this.prisma.workspaceMember.findFirst({
+      where: {
+        workspaceId,
+        user: { email: recipientEmail },
+      },
+    });
+
+    if (existingMember) {
+      throw new ConflictException(
+        'User is already a member of this workspace.',
+      );
+    }
+
+    // 3. Check for existing pending invitation
+    const existingInvitation = await this.prisma.workspaceInvitation.findFirst(
+      {
+        where: {
+          workspaceId,
+          email: recipientEmail,
+          status: InvitationStatus.PENDING,
+        },
+      },
+    );
+
+    if (existingInvitation) {
+      throw new ConflictException(
+        'A pending invitation already exists for this email.',
+      );
+    }
+
+    // 4. Create workspace invitation record
+    const invitation = await this.prisma.workspaceInvitation.create({
+      data: {
+        workspaceId,
+        inviterId,
+        email: recipientEmail,
+        role: dto.role || WorkspaceRole.MEMBER,
+        status: InvitationStatus.PENDING,
+        token: crypto.randomUUID(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days expiry
+      },
+    });
+
+    // 5. Send email notification asynchronously
+    await this.emailService.sendWorkspaceInvitationEmail({
+      to: recipientEmail,
+      workspaceName: membership.workspace.name,
+      inviterName: inviterId,
+      invitationToken: invitation.token,
+    });
+
+    return invitation;
+  }
+
+  /**
+   * Accepts a pending workspace invitation.
+   */
+  async acceptInvitation(token: string, userId: string) {
+    const invitation = await this.validateInvitationToken(token);
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user || user.email.toLowerCase() !== invitation.email.toLowerCase()) {
+      throw new ForbiddenException(
+        'This invitation was sent to a different email address.',
+      );
+    }
+
+    // Process acceptance in a database transaction
+    return this.prisma.$transaction(async (tx) => {
+      // Create membership record
+      await tx.workspaceMember.create({
+        data: {
+          workspaceId: invitation.workspaceId,
+          userId,
+          role: invitation.role,
+        },
+      });
+
+      // Mark invitation status as ACCEPTED
+      return tx.workspaceInvitation.update({
+        where: { id: invitation.id },
+        data: { status: InvitationStatus.ACCEPTED },
+      });
+    });
+  }
+
+  /**
+   * Declines a pending workspace invitation.
+   */
+  async declineInvitation(token: string, userId: string) {
+    const invitation = await this.validateInvitationToken(token);
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user || user.email.toLowerCase() !== invitation.email.toLowerCase()) {
+      throw new ForbiddenException(
+        'This invitation was sent to a different email address.',
+      );
+    }
+
+    return this.prisma.workspaceInvitation.update({
+      where: { id: invitation.id },
+      data: { status: InvitationStatus.DECLINED },
+    });
+  }
+
+  /**
+   * Helper to validate token freshness and status.
+   */
+  private async validateInvitationToken(token: string) {
+    const invitation = await this.prisma.workspaceInvitation.findUnique({
+      where: { token },
+    });
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation token is invalid or expired.');
+    }
+
+    if (invitation.status !== InvitationStatus.PENDING) {
+      throw new BadRequestException(
+        `Invitation has already been ${invitation.status.toLowerCase()}.`,
+      );
+    }
+
+    if (invitation.expiresAt < new Date()) {
+      await this.prisma.workspaceInvitation.update({
+        where: { id: invitation.id },
+        data: { status: InvitationStatus.EXPIRED },
+      });
+      throw new BadRequestException('Invitation link has expired.');
+    }
+
+    return invitation;
+  }
+}


### PR DESCRIPTION
# 🎯 Overview
Resolves  #50

Implements structured onboarding and invitation workflows for shared workspaces:
* Workspace Owners and Admins can generate and send workspace invitation tokens via email.
* Recipients can accept or decline invitations with state transitions (`PENDING`, `ACCEPTED`, `DECLINED`, `EXPIRED`).
* Enforces role privilege checks and email matching on acceptance.

---

## 🛠️ Key Architectural Changes

### 1. Workspaces Domain (`backend/src/workspaces/workspace-invitations.service.ts`)
* Added `createInvitation`, `acceptInvitation`, and `declineInvitation` handlers.
* Implemented token expiration verification (7 days default) and transactional membership creation upon acceptance.

### 2. Email Service Hook (`backend/src/email/email.service.ts`)
* Wired template notification logic for outbound workspace invite dispatching.

---

## 🧪 Testing & Verification

### Unit Testing
```bash
npm run test backend/src/workspaces/workspace-invitations.service.spec.ts