### PR TITLE
feat(backend): add URI-based API versioning with version headers (Closes #33)

### DIFF
--- a/backend/src/common/middlewares/api-version.middleware.spec.ts
+++ b/backend/src/common/middlewares/api-version.middleware.spec.ts
@@ -1,0 +1,46 @@
+import { ApiVersionMiddleware, CURRENT_API_VERSION, SUPPORTED_API_VERSIONS } from './api-version.middleware';
+
+describe('ApiVersionMiddleware', () => {
+  let middleware: ApiVersionMiddleware;
+  let req: any;
+  let res: any;
+  let nextFn: jest.Mock;
+
+  beforeEach(() => {
+    middleware = new ApiVersionMiddleware();
+    req = { params: {} };
+    res = { setHeader: jest.fn() };
+    nextFn = jest.fn();
+  });
+
+  it('sets X-API-Version header from route param', () => {
+    req.params.version = '1';
+    middleware.use(req, res, nextFn);
+    expect(res.setHeader).toHaveBeenCalledWith('X-API-Version', '1');
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it('falls back to CURRENT_API_VERSION when no version param', () => {
+    middleware.use(req, res, nextFn);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'X-API-Version',
+      CURRENT_API_VERSION,
+    );
+  });
+
+  it('sets X-API-Versions-Supported header', () => {
+    middleware.use(req, res, nextFn);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'X-API-Versions-Supported',
+      SUPPORTED_API_VERSIONS.join(', '),
+    );
+  });
+
+  it('does not set Deprecation header for non-deprecated version', () => {
+    req.params.version = '1';
+    middleware.use(req, res, nextFn);
+    const headerNames = res.setHeader.mock.calls.map((c: any[]) => c[0]);
+    expect(headerNames).not.toContain('Deprecation');
+    expect(headerNames).not.toContain('Sunset');
+  });
+});

--- a/backend/src/common/middlewares/api-version.middleware.ts
+++ b/backend/src/common/middlewares/api-version.middleware.ts
@@ -1,0 +1,39 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+export const CURRENT_API_VERSION = '1';
+export const SUPPORTED_API_VERSIONS = ['1'] as const;
+export const DEPRECATED_API_VERSIONS: string[] = [];
+export const SUNSET_DATE = '2027-01-01';
+
+/**
+ * Middleware that adds API version metadata to every response.
+ *
+ * - `X-API-Version`: the resolved version serving this request.
+ * - `X-API-Versions-Supported`: comma-separated list of active versions.
+ * - `Sunset` and `Deprecation` headers when the version is deprecated.
+ */
+@Injectable()
+export class ApiVersionMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const version =
+      (req.params?.version as string) ?? CURRENT_API_VERSION;
+
+    res.setHeader('X-API-Version', version);
+    res.setHeader(
+      'X-API-Versions-Supported',
+      SUPPORTED_API_VERSIONS.join(', '),
+    );
+
+    if (DEPRECATED_API_VERSIONS.includes(version)) {
+      res.setHeader('Deprecation', 'true');
+      res.setHeader('Sunset', new Date(SUNSET_DATE).toUTCString());
+      res.setHeader(
+        'X-API-Warn',
+        `Version ${version} is deprecated. Migrate to v${CURRENT_API_VERSION} before ${SUNSET_DATE}.`,
+      );
+    }
+
+    next();
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { VersioningType } from '@nestjs/common';
 import { AppModule } from './app.module';
 import {
   DocumentBuilder,
@@ -11,6 +12,10 @@ import { HttpLogger } from './common/middlewares/httpLogger.middleware';
 import { CorrelationIdMiddleware } from './common/middlewares/correlation-id.middleware';
 import { CentralizedValidationPipe } from './common/pipes/validation.pipe';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
+import {
+  ApiVersionMiddleware,
+  CURRENT_API_VERSION,
+} from './common/middlewares/api-version.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { rawBody: true });
@@ -48,6 +53,23 @@ async function bootstrap() {
     credentials: true,
   });
 
+  // API VERSIONING (BE-25)
+  //
+  // URI-based versioning: every route is prefixed with /api/vN/.
+  // The default version is "1" so unversioned calls fall through to v1.
+  // A middleware adds X-API-Version and X-API-Versions-Supported headers.
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: CURRENT_API_VERSION,
+  });
+
+  // API VERSION HEADER MIDDLEWARE
+  app.use(new ApiVersionMiddleware().use);
+
+  // GLOBAL PREFIX — must be set AFTER enableVersioning so NestJS
+  // places the version segment between /api and the controller route.
+  app.setGlobalPrefix('/api');
+
   // SWAGGER SETUP (BE-09 acceptance)
   //
   // The CLI plugin (configured in nest-cli.json) augments every
@@ -61,8 +83,21 @@ async function bootstrap() {
     .setDescription(
       `REST API for the Oraculum platform.
 
+## API Versioning (BE-25)
+All endpoints are versioned via URI prefix: \`/api/v1/\`, \`/api/v2/\`, etc.
+The current stable version is **v1**. Always use the versioned URL.
+
+### Response Headers
+Every response includes:
+- \`X-API-Version\`: the version that served the request.
+- \`X-API-Versions-Supported\`: list of active versions.
+
+### Deprecation
+Deprecated versions emit \`Deprecation: true\` and \`Sunset\` headers.
+Migrate to the latest version before the sunset date.
+
 ## Authentication
-Most endpoints require a JWT bearer token. Obtain one via \`POST /api/auth/login\` and pass it as \`Authorization: Bearer <token>\`.
+Most endpoints require a JWT bearer token. Obtain one via \`POST /api/v1/auth/login\` and pass it as \`Authorization: Bearer <token>\`.
 
 ## Rate limiting (BE-07)
 Every endpoint is rate-limited. Authenticated requests are tracked per user; anonymous requests are tracked per IP. The default limits are 60 requests/minute (anonymous) and 100 requests/minute (authenticated). Look for the \`Retry-After\` header on 429 responses.
@@ -85,7 +120,7 @@ List endpoints accept \`page\` (default 1) and \`limit\` (default 20, max 100). 
         type: 'http',
         scheme: 'bearer',
         bearerFormat: 'JWT',
-        description: 'JWT access token issued by /api/auth/login',
+        description: 'JWT access token issued by /api/v1/auth/login',
         name: 'Authorization',
         in: 'header',
       },
@@ -108,8 +143,6 @@ List endpoints accept \`page\` (default 1) and \`limit\` (default 20, max 100). 
   };
 
   SwaggerModule.setup('swagger', app as any, document, ui);
-
-  app.setGlobalPrefix('/api');
 
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');
   console.log(`Server is listening at: ${await app.getUrl()}`);


### PR DESCRIPTION
## Summary

Adds URI-based API versioning strategy to the Oraculum backend.

### Changes

#### `backend/src/main.ts`
- Configured `NestFactory.enableVersioning()` with `VersioningType.URI`
- Set default version to `"1"` via `CURRENT_API_VERSION`
- Routes now resolve as `/api/v1/{controller}` (e.g. `/api/v1/auth/login`)
- Swagger docs updated with versioning documentation
- Added `ApiVersionMiddleware` globally

#### `backend/src/common/middlewares/api-version.middleware.ts` (new)
- Adds `X-API-Version` response header on every request
- Adds `X-API-Versions-Supported` header listing active versions
- Supports `Deprecation`, `Sunset`, and `X-API-Warn` headers for deprecated versions
- Exports constants: `CURRENT_API_VERSION`, `SUPPORTED_API_VERSIONS`, `DEPRECATED_API_VERSIONS`, `SUNSET_DATE`

#### `backend/src/common/middles/api-version.middleware.spec.ts` (new)
- Unit tests for version header middleware

### API Versioning Strategy

| Concept | Detail |
|---|---|
| Type | URI-based (`/api/v1/`, `/api/v2/`) |
| Current version | `v1` |
| Default version | `v1` (unversioned calls fall through) |
| Deprecation | `Deprecation: true` + `Sunset` header + `X-API-Warn` |
| Response headers | `X-API-Version`, `X-API-Versions-Supported` |

### Migration notes
- All existing routes now require `/v1/` prefix (e.g. `/api/auth/login` -> `/api/v1/auth/login`)
- Clients should update base URLs to include the version segment

Closes #33