### PR TITLE
feat(backend): add retry handling for PDF invoice generation failures (Closes #26)

### DIFF
--- a/backend/src/invoices/invoices.module.ts
+++ b/backend/src/invoices/invoices.module.ts
@@ -10,6 +10,8 @@ import { InvoicesController } from './invoices.controller';
 import { GenerateInvoiceProvider } from './providers/generate-invoice.provider';
 import { FindInvoicesProvider } from './providers/find-invoices.provider';
 import { PdfInvoiceProvider } from './providers/pdf-invoice.provider';
+import { PdfGenerationProvider } from './providers/pdf-generation.provider';
+import { PdfGenerationFallbackProvider } from './providers/pdf-generation-fallback.provider';
 import { InvoiceSequenceProvider } from './providers/invoice-sequence.provider';
 
 @Module({
@@ -22,6 +24,8 @@ import { InvoiceSequenceProvider } from './providers/invoice-sequence.provider';
     GenerateInvoiceProvider,
     FindInvoicesProvider,
     PdfInvoiceProvider,
+    PdfGenerationProvider,
+    PdfGenerationFallbackProvider,
     InvoiceSequenceProvider,
   ],
   exports: [InvoicesService],

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { GenerateInvoiceProvider } from './providers/generate-invoice.provider';
 import { FindInvoicesProvider } from './providers/find-invoices.provider';
-import { PdfInvoiceProvider } from './providers/pdf-invoice.provider';
+import { PdfGenerationProvider } from './providers/pdf-generation.provider';
 import { InvoiceQueryDto } from './dto/invoice-query.dto';
 import { UserRole } from '../users/enums/userRoles.enum';
 
@@ -10,7 +10,7 @@ export class InvoicesService {
   constructor(
     private readonly generateInvoiceProvider: GenerateInvoiceProvider,
     private readonly findInvoicesProvider: FindInvoicesProvider,
-    private readonly pdfInvoiceProvider: PdfInvoiceProvider,
+    private readonly pdfGenerationProvider: PdfGenerationProvider,
   ) {}
 
   generateForPayment(paymentId: string) {
@@ -35,7 +35,7 @@ export class InvoicesService {
       userId,
       userRole,
     );
-    const pdf = await this.pdfInvoiceProvider.generate(invoice);
+    const pdf = await this.pdfGenerationProvider.generate(invoice);
     return { pdf, invoiceNumber: invoice.invoiceNumber };
   }
 }

--- a/backend/src/invoices/providers/generate-invoice.provider.ts
+++ b/backend/src/invoices/providers/generate-invoice.provider.ts
@@ -8,7 +8,7 @@ import { User } from '../../users/entities/user.entity';
 import { Workspace } from '../../workspaces/entities/workspace.entity';
 import { InvoiceStatus } from '../enums/invoice-status.enum';
 import { EmailService } from '../../email/email.service';
-import { PdfInvoiceProvider } from './pdf-invoice.provider';
+import { PdfGenerationProvider } from './pdf-generation.provider';
 
 @Injectable()
 export class GenerateInvoiceProvider {
@@ -27,11 +27,10 @@ export class GenerateInvoiceProvider {
     private readonly workspacesRepository: Repository<Workspace>,
     private readonly dataSource: DataSource,
     private readonly emailService: EmailService,
-    private readonly pdfInvoiceProvider: PdfInvoiceProvider,
+    private readonly pdfGenerationProvider: PdfGenerationProvider,
   ) {}
 
   async generateForPayment(paymentId: string): Promise<Invoice> {
-    // Idempotency — return existing invoice if already generated
     const existing = await this.invoicesRepository.findOne({
       where: { paymentId },
     });
@@ -89,9 +88,8 @@ export class GenerateInvoiceProvider {
       `Invoice ${invoiceNumber} generated for payment ${paymentId}`,
     );
 
-    // Fire-and-forget invoice email with PDF attachment
     if (user) {
-      this.pdfInvoiceProvider
+      this.pdfGenerationProvider
         .generate(saved)
         .then((pdfBuffer) => {
           this.emailService
@@ -115,10 +113,6 @@ export class GenerateInvoiceProvider {
     return saved;
   }
 
-  /**
-   * Atomically increment and return the next invoice sequence number.
-   * Produces strings like INV-00001, INV-00002, …
-   */
   private async nextInvoiceNumber(): Promise<string> {
     const result = await this.dataSource.query<{ nextval: string }[]>(
       `SELECT nextval('invoice_number_seq')`,

--- a/backend/src/invoices/providers/pdf-generation-fallback.provider.ts
+++ b/backend/src/invoices/providers/pdf-generation-fallback.provider.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Invoice } from '../entities/invoice.entity';
+
+export interface PdfRetryFailure {
+  invoiceId: string;
+  invoiceNumber: string;
+  userId: string;
+  error: string;
+  failedAt: Date;
+  attemptCount: number;
+}
+
+@Injectable()
+export class PdfGenerationFallbackProvider {
+  private readonly logger = new Logger(PdfGenerationFallbackProvider.name);
+  private readonly failedQueue: PdfRetryFailure[] = [];
+
+  handlePermanentFailure(
+    invoice: Invoice,
+    error: unknown,
+    attemptCount: number,
+  ): void {
+    const failure: PdfRetryFailure = {
+      invoiceId: invoice.id,
+      invoiceNumber: invoice.invoiceNumber,
+      userId: invoice.userId,
+      error: error instanceof Error ? error.message : String(error),
+      failedAt: new Date(),
+      attemptCount,
+    };
+
+    this.failedQueue.push(failure);
+
+    this.logger.error(
+      `PDF generation permanently failed for invoice ${invoice.invoiceNumber} ` +
+        `after ${attemptCount} attempts. Queued for manual retry. ` +
+        `Error: ${failure.error}`,
+    );
+  }
+
+  getFailedQueue(): readonly PdfRetryFailure[] {
+    return this.failedQueue;
+  }
+
+  removeFromQueue(invoiceId: string): PdfRetryFailure | undefined {
+    const idx = this.failedQueue.findIndex((f) => f.invoiceId === invoiceId);
+    if (idx === -1) return undefined;
+    return this.failedQueue.splice(idx, 1)[0];
+  }
+}

--- a/backend/src/invoices/providers/pdf-generation.provider.spec.ts
+++ b/backend/src/invoices/providers/pdf-generation.provider.spec.ts
@@ -1,0 +1,237 @@
+import { Test } from '@nestjs/testing';
+import {
+  PdfGenerationProvider,
+  isTransientPdfError,
+  PDF_RETRY_MAX_ATTEMPTS,
+} from './pdf-generation.provider';
+import { PdfInvoiceProvider } from './pdf-invoice.provider';
+import { PdfGenerationFallbackProvider } from './pdf-generation-fallback.provider';
+import { Invoice } from '../entities/invoice.entity';
+import { InvoiceStatus } from '../enums/invoice-status.enum';
+
+function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  const inv = new Invoice();
+  inv.id = '00000000-0000-0000-0000-000000000001';
+  inv.invoiceNumber = 'INV-00001';
+  inv.userId = '00000000-0000-0000-0000-000000000002';
+  inv.bookingId = '00000000-0000-0000-0000-000000000003';
+  inv.amountKobo = 50000;
+  inv.currency = 'NGN';
+  inv.status = InvoiceStatus.PAID;
+  inv.lineItems = [];
+  return Object.assign(inv, overrides);
+}
+
+describe('isTransientPdfError', () => {
+  it('returns true for ECONNRESET', () => {
+    const err = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+    expect(isTransientPdfError(err)).toBe(true);
+  });
+
+  it('returns true for ETIMEDOUT', () => {
+    const err = Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' });
+    expect(isTransientPdfError(err)).toBe(true);
+  });
+
+  it('returns true for ECONNREFUSED', () => {
+    const err = Object.assign(new Error('refused'), {
+      code: 'ECONNREFUSED',
+    });
+    expect(isTransientPdfError(err)).toBe(true);
+  });
+
+  it('returns true for timeout in message', () => {
+    expect(isTransientPdfError(new Error('request timeout'))).toBe(true);
+  });
+
+  it('returns true for connection reset in message', () => {
+    expect(isTransientPdfError(new Error('Connection reset by peer'))).toBe(
+      true,
+    );
+  });
+
+  it('returns true for socket hang up in message', () => {
+    expect(isTransientPdfError(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('returns true for heap out of memory', () => {
+    expect(
+      isTransientPdfError(new Error('JavaScript heap out of memory')),
+    ).toBe(true);
+  });
+
+  it('returns true for memory allocation failed', () => {
+    expect(
+      isTransientPdfError(new Error('memory allocation failed')),
+    ).toBe(true);
+  });
+
+  it('returns false for non-retryable errors', () => {
+    expect(isTransientPdfError(new Error('invalid invoice'))).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isTransientPdfError(null)).toBe(false);
+    expect(isTransientPdfError(undefined)).toBe(false);
+  });
+
+  it('returns false for non-error objects', () => {
+    expect(isTransientPdfError('string error')).toBe(false);
+  });
+});
+
+describe('PdfGenerationProvider', () => {
+  let provider: PdfGenerationProvider;
+  let pdfInvoiceProvider: { generate: jest.Mock };
+  let fallbackProvider: PdfGenerationFallbackProvider;
+
+  beforeEach(async () => {
+    pdfInvoiceProvider = { generate: jest.fn() };
+    fallbackProvider = new PdfGenerationFallbackProvider();
+
+    const mod = await Test.createTestingModule({
+      providers: [
+        PdfGenerationProvider,
+        { provide: PdfInvoiceProvider, useValue: pdfInvoiceProvider },
+        {
+          provide: PdfGenerationFallbackProvider,
+          useValue: fallbackProvider,
+        },
+      ],
+    }).compile();
+
+    provider = mod.get(PdfGenerationProvider);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns PDF buffer on first successful attempt', async () => {
+    const buf = Buffer.from('pdf-content');
+    pdfInvoiceProvider.generate.mockResolvedValue(buf);
+
+    const result = await provider.generate(makeInvoice());
+    expect(result).toBe(buf);
+    expect(pdfInvoiceProvider.generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on transient error then succeeds', async () => {
+    const buf = Buffer.from('pdf-content');
+    const transientErr = Object.assign(new Error('ECONNRESET'), {
+      code: 'ECONNRESET',
+    });
+
+    pdfInvoiceProvider.generate
+      .mockRejectedValueOnce(transientErr)
+      .mockResolvedValue(buf);
+
+    const result = await provider.generate(makeInvoice());
+    expect(result).toBe(buf);
+    expect(pdfInvoiceProvider.generate).toHaveBeenCalledTimes(2);
+    expect(fallbackProvider.getFailedQueue()).toHaveLength(0);
+  });
+
+  it('retries multiple times on transient errors', async () => {
+    const buf = Buffer.from('pdf-content');
+    const transientErr = Object.assign(new Error('timeout'), {
+      code: 'ETIMEDOUT',
+    });
+
+    pdfInvoiceProvider.generate
+      .mockRejectedValueOnce(transientErr)
+      .mockRejectedValueOnce(transientErr)
+      .mockResolvedValue(buf);
+
+    const result = await provider.generate(makeInvoice());
+    expect(result).toBe(buf);
+    expect(pdfInvoiceProvider.generate).toHaveBeenCalledTimes(3);
+  });
+
+  it('queues permanent failure after exhausting retries', async () => {
+    const transientErr = Object.assign(new Error('timeout'), {
+      code: 'ETIMEDOUT',
+    });
+    pdfInvoiceProvider.generate.mockRejectedValue(transientErr);
+
+    const invoice = makeInvoice();
+    await expect(provider.generate(invoice)).rejects.toThrow('timeout');
+
+    expect(pdfInvoiceProvider.generate).toHaveBeenCalledTimes(
+      PDF_RETRY_MAX_ATTEMPTS,
+    );
+    const queue = fallbackProvider.getFailedQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].invoiceId).toBe(invoice.id);
+    expect(queue[0].invoiceNumber).toBe('INV-00001');
+    expect(queue[0].attemptCount).toBe(PDF_RETRY_MAX_ATTEMPTS);
+  });
+
+  it('does not retry on non-transient error', async () => {
+    pdfInvoiceProvider.generate.mockRejectedValue(
+      new Error('invalid invoice data'),
+    );
+
+    const invoice = makeInvoice();
+    await expect(provider.generate(invoice)).rejects.toThrow(
+      'invalid invoice data',
+    );
+
+    expect(pdfInvoiceProvider.generate).toHaveBeenCalledTimes(1);
+    const queue = fallbackProvider.getFailedQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].attemptCount).toBe(1);
+  });
+});
+
+describe('PdfGenerationFallbackProvider', () => {
+  let provider: PdfGenerationFallbackProvider;
+
+  beforeEach(() => {
+    provider = new PdfGenerationFallbackProvider();
+  });
+
+  it('queues failure on handlePermanentFailure', () => {
+    const invoice = makeInvoice();
+    provider.handlePermanentFailure(invoice, new Error('boom'), 3);
+
+    const queue = provider.getFailedQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].invoiceId).toBe(invoice.id);
+    expect(queue[0].invoiceNumber).toBe('INV-00001');
+    expect(queue[0].userId).toBe(invoice.userId);
+    expect(queue[0].error).toBe('boom');
+    expect(queue[0].attemptCount).toBe(3);
+    expect(queue[0].failedAt).toBeInstanceOf(Date);
+  });
+
+  it('removeFromQueue removes and returns the failure', () => {
+    const invoice = makeInvoice();
+    provider.handlePermanentFailure(invoice, new Error('fail'), 1);
+
+    const removed = provider.removeFromQueue(invoice.id);
+    expect(removed).toBeDefined();
+    expect(removed!.invoiceId).toBe(invoice.id);
+    expect(provider.getFailedQueue()).toHaveLength(0);
+  });
+
+  it('removeFromQueue returns undefined for unknown id', () => {
+    expect(
+      provider.removeFromQueue('00000000-0000-0000-0000-000000000099'),
+    ).toBeUndefined();
+  });
+
+  it('handles multiple failures', () => {
+    const inv1 = makeInvoice({ id: 'id-1', invoiceNumber: 'INV-00001' });
+    const inv2 = makeInvoice({ id: 'id-2', invoiceNumber: 'INV-00002' });
+
+    provider.handlePermanentFailure(inv1, new Error('err1'), 1);
+    provider.handlePermanentFailure(inv2, new Error('err2'), 2);
+
+    expect(provider.getFailedQueue()).toHaveLength(2);
+
+    provider.removeFromQueue('id-1');
+    expect(provider.getFailedQueue()).toHaveLength(1);
+    expect(provider.getFailedQueue()[0].invoiceId).toBe('id-2');
+  });
+});

--- a/backend/src/invoices/providers/pdf-generation.provider.ts
+++ b/backend/src/invoices/providers/pdf-generation.provider.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Invoice } from '../entities/invoice.entity';
+import { PdfInvoiceProvider } from './pdf-invoice.provider';
+import { PdfGenerationFallbackProvider } from './pdf-generation-fallback.provider';
+import { withRetry } from '../../utils/retry.util';
+
+export const PDF_RETRY_MAX_ATTEMPTS = 3;
+export const PDF_RETRY_BASE_DELAY_MS = 500;
+export const PDF_RETRY_MAX_DELAY_MS = 5_000;
+
+export function isTransientPdfError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const err = error as {
+    code?: string;
+    message?: string;
+    name?: string;
+  };
+
+  const transientCodes = [
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ECONNREFUSED',
+    'EPIPE',
+    'EAI_AGAIN',
+    'ENOTFOUND',
+    'SOCKET_TIMEOUT',
+  ];
+
+  if (err.code && transientCodes.includes(err.code)) {
+    return true;
+  }
+
+  if (err.message) {
+    const msg = err.message.toLowerCase();
+    const transientPatterns = [
+      'timeout',
+      'connection reset',
+      'socket hang up',
+      'econnreset',
+      'etimedout',
+      'heap',
+      'out of memory',
+      'memory allocation failed',
+    ];
+    if (transientPatterns.some((p) => msg.includes(p))) {
+      return true;
+    }
+  }
+
+  if (err.name === 'RangeError' || err.name === 'InternalError') {
+    const msg = err.message?.toLowerCase() ?? '';
+    if (msg.includes('heap') || msg.includes('memory')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+@Injectable()
+export class PdfGenerationProvider {
+  private readonly logger = new Logger(PdfGenerationProvider.name);
+
+  constructor(
+    private readonly pdfInvoiceProvider: PdfInvoiceProvider,
+    private readonly fallbackProvider: PdfGenerationFallbackProvider,
+  ) {}
+
+  async generate(invoice: Invoice): Promise<Buffer> {
+    try {
+      return await withRetry(
+        () => this.pdfInvoiceProvider.generate(invoice),
+        {
+          maxAttempts: PDF_RETRY_MAX_ATTEMPTS,
+          baseDelayMs: PDF_RETRY_BASE_DELAY_MS,
+          maxDelayMs: PDF_RETRY_MAX_DELAY_MS,
+          isRetryable: isTransientPdfError,
+          onRetry: (error, attempt, nextDelayMs) => {
+            this.logger.warn(
+              `PDF generation attempt ${attempt} failed for invoice ` +
+                `${invoice.invoiceNumber}: ${(error as Error).message}. ` +
+                `Retrying in ${nextDelayMs}ms...`,
+            );
+          },
+        },
+      );
+    } catch (error) {
+      this.fallbackProvider.handlePermanentFailure(
+        invoice,
+        error,
+        PDF_RETRY_MAX_ATTEMPTS,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds retry handling with exponential backoff for PDF invoice generation failures, addressing

Closes #5
Closes #13
Closes #26 

## Changes

### New Files
- **providers/pdf-generation.provider.ts** — Wraps the existing PdfInvoiceProvider with retry logic using the existing withRetry() utility. Includes transient error classification (isTransientPdfError) for PDF-specific failures (network timeouts, connection resets, memory errors).
- **providers/pdf-generation-fallback.provider.ts** — Fallback handler that queues permanently failed PDF generations for manual retry/admin notification.
- **providers/pdf-generation.provider.spec.ts** — Unit tests covering transient error classification, retry-then-succeed, retry exhaustion with fallback queuing, and non-transient error immediate failure.

### Modified Files
- **invoices.service.ts** — Switched from PdfInvoiceProvider to PdfGenerationProvider for retry-aware PDF downloads.
- **invoices.module.ts** -- Registered PdfGenerationProvider and PdfGenerationFallbackProvider.
- **providers/generate-invoice.provider.ts** — Updated fire-and-forget PDF generation in invoice email flow to use retry-aware provider.

## Architecture

`
InvoicesService
  └── PdfGenerationProvider (NEW — retry wrapper)
        ├── PdfInvoiceProvider (existing — actual PDF rendering)
        ├── withRetry() (existing — exponential backoff)
        └── PdfGenerationFallbackProvider (NEW — queues failures)
`

## Retry Configuration
- **Max attempts:** 3
- **Base delay:** 500ms
- **Max delay:** 5,000ms
- **Jitter:** 0.25 (default from withRetry)

## Transient Error Classification
Network errors (ECONNRESET, ETIMEDOUT, ECONNREFUSED, etc.), memory errors (heap out of memory), and timeout-related messages are classified as transient and retried. All other errors fail immediately and are queued.