### PR TITLE
feat(backend): add structured logs for payment failure investigations (Closes #36)

### DIFF
--- a/backend/src/audit/audit-payment-actions.spec.ts
+++ b/backend/src/audit/audit-payment-actions.spec.ts
@@ -1,0 +1,104 @@
+import { AuditService, AuditAction } from './audit.service';
+import { AuditLog } from './entities/audit-log.entity';
+import { Repository } from 'typeorm';
+import { runWithRequestContext } from '../common/context/correlation-context';
+
+describe('AuditService - Payment Actions', () => {
+  let repoCreate: jest.Mock;
+  let repoSave: jest.Mock;
+  let service: AuditService;
+
+  beforeEach(() => {
+    repoCreate = jest.fn((row: Partial<AuditLog>) => ({
+      id: 'audit-row-id',
+      createdAt: new Date(),
+      ...row,
+    } as AuditLog));
+    repoSave = jest.fn(async (row: AuditLog) => row);
+    const repo = { create: repoCreate, save: repoSave } as unknown as Repository<AuditLog>;
+    service = new AuditService(repo);
+  });
+
+  describe('paymentFailure', () => {
+    it('logs a payment failure with structured metadata', async () => {
+      await runWithRequestContext(
+        { correlationId: 'cid-pay-fail-1', request: { ip: '10.0.0.1', userAgent: 'jest' } },
+        async () => {
+          await service.paymentFailure('payment-123', 'user-456', {
+            paymentReference: 'ref-abc',
+            amount: 50000,
+            currency: 'NGN',
+            provider: 'paystack',
+            errorCode: 'CHARGE_FAILED',
+            errorMessage: 'Paystack charge.failed webhook received',
+            providerResponse: null,
+          });
+        },
+      );
+
+      expect(repoCreate).toHaveBeenCalledTimes(1);
+      const row = repoCreate.mock.calls[0][0] as Partial<AuditLog>;
+      expect(row).toMatchObject({
+        action: AuditAction.PAYMENT_FAILED,
+        outcome: 'FAILURE',
+        actorId: 'user-456',
+        resourceType: 'Payment',
+        resourceId: 'payment-123',
+        correlationId: 'cid-pay-fail-1',
+      });
+      expect(row.metadata).toMatchObject({
+        paymentReference: 'ref-abc',
+        amount: 50000,
+        provider: 'paystack',
+        errorCode: 'CHARGE_FAILED',
+      });
+    });
+
+    it('logs without userId for anonymous', async () => {
+      await service.paymentFailure('payment-789', null, {
+        paymentReference: 'ref-anon',
+        errorCode: 'CHARGE_FAILED',
+        errorMessage: 'Charge failed',
+      });
+
+      const row = repoCreate.mock.calls[0][0] as Partial<AuditLog>;
+      expect(row.action).toBe(AuditAction.PAYMENT_FAILED);
+      expect(row.outcome).toBe('FAILURE');
+      expect(row.actorId).toBeNull();
+      expect(row.resourceType).toBe('Payment');
+    });
+  });
+
+  describe('paymentSuccess', () => {
+    it('logs a payment success with structured metadata', async () => {
+      await service.paymentSuccess('payment-abc', 'user-xyz', {
+        paymentReference: 'ref-123',
+        amount: 100000,
+        currency: 'NGN',
+        provider: 'paystack',
+        bookingId: 'booking-001',
+      });
+
+      const row = repoCreate.mock.calls[0][0] as Partial<AuditLog>;
+      expect(row).toMatchObject({
+        action: AuditAction.PAYMENT_SUCCESS,
+        outcome: 'SUCCESS',
+        actorId: 'user-xyz',
+        resourceType: 'Payment',
+        resourceId: 'payment-abc',
+      });
+      expect(row.metadata).toMatchObject({
+        paymentReference: 'ref-123',
+        amount: 100000,
+        bookingId: 'booking-001',
+      });
+    });
+  });
+
+  describe('payment action codes', () => {
+    it('PAYMENT_FAILED exists', () => expect(AuditAction.PAYMENT_FAILED).toBe('PAYMENT_FAILED'));
+    it('PAYMENT_SUCCESS exists', () => expect(AuditAction.PAYMENT_SUCCESS).toBe('PAYMENT_SUCCESS'));
+    it('PAYMENT_INITIATED exists', () => expect(AuditAction.PAYMENT_INITIATED).toBe('PAYMENT_INITIATED'));
+    it('PAYMENT_REFUNDED exists', () => expect(AuditAction.PAYMENT_REFUNDED).toBe('PAYMENT_REFUNDED'));
+  });
+});

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -49,6 +49,16 @@ export const AuditAction = {
   CONTACT_MARKED_READ: 'CONTACT_MARKED_READ',
   CONTACT_DELETED: 'CONTACT_DELETED',
   CONTACT_RESTORED: 'CONTACT_RESTORED',
+  // Payments
+  PAYMENT_INITIATED: 'PAYMENT_INITIATED',
+  PAYMENT_SUCCESS: 'PAYMENT_SUCCESS',
+  PAYMENT_FAILED: 'PAYMENT_FAILED',
+  PAYMENT_REFUNDED: 'PAYMENT_REFUNDED',
+  PAYMENT_WEBHOOK_RECEIVED: 'PAYMENT_WEBHOOK_RECEIVED',
+  PAYMENT_RECONCILED: 'PAYMENT_RECONCILED',
+  // Invoices
+  INVOICE_GENERATED: 'INVOICE_GENERATED',
+  INVOICE_RECONCILED: 'INVOICE_RECONCILED',
 } as const;
 
 export type AuditActionCode =
@@ -182,6 +192,36 @@ export class AuditService {
       actor,
       resourceType,
       resourceId,
+      metadata,
+    });
+  }
+
+  paymentFailure(
+    paymentId: string,
+    userId: string | null,
+    metadata: Record<string, unknown>,
+  ) {
+    return this.log({
+      action: AuditAction.PAYMENT_FAILED,
+      outcome: 'FAILURE',
+      actor: userId ? { id: userId } : undefined,
+      resourceType: 'Payment',
+      resourceId: paymentId,
+      metadata,
+    });
+  }
+
+  paymentSuccess(
+    paymentId: string,
+    userId: string,
+    metadata?: Record<string, unknown>,
+  ) {
+    return this.log({
+      action: AuditAction.PAYMENT_SUCCESS,
+      outcome: 'SUCCESS',
+      actor: { id: userId },
+      resourceType: 'Payment',
+      resourceId: paymentId,
       metadata,
     });
   }

--- a/backend/src/payments/dto/payment-failure-query.dto.ts
+++ b/backend/src/payments/dto/payment-failure-query.dto.ts
@@ -1,0 +1,37 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class PaymentFailureQueryDto extends PaginationDto {
+  @ApiPropertyOptional({ format: 'uuid' })
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+
+  @ApiPropertyOptional({ format: 'uuid' })
+  @IsOptional()
+  @IsUUID()
+  paymentId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by provider' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  provider?: string;
+
+  @ApiPropertyOptional({ example: '2026-07-01' })
+  @IsOptional()
+  @IsString()
+  fromDate?: string;
+
+  @ApiPropertyOptional({ example: '2026-07-31' })
+  @IsOptional()
+  @IsString()
+  toDate?: string;
+
+  @ApiPropertyOptional({ description: 'Free-text search across error codes, messages, and metadata' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  search?: string;
+}

--- a/backend/src/payments/payment-failure-logs.controller.spec.ts
+++ b/backend/src/payments/payment-failure-logs.controller.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PaymentFailureLogsController } from './payment-failure-logs.controller';
+import { AuditLog } from '../audit/entities/audit-log.entity';
+import { AuditAction } from '../audit/audit.service';
+
+describe('PaymentFailureLogsController', () => {
+  let controller: PaymentFailureLogsController;
+
+  const mockQb = {
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getCount: jest.fn().mockResolvedValue(0),
+    getMany: jest.fn().mockResolvedValue([]),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PaymentFailureLogsController],
+      providers: [
+        {
+          provide: getRepositoryToken(AuditLog),
+          useValue: { createQueryBuilder: jest.fn(() => mockQb) },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(PaymentFailureLogsController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('filters by PAYMENT_FAILED action', async () => {
+    await controller.list({ page: 1, limit: 20 });
+    expect(mockQb.andWhere).toHaveBeenCalledWith('a.action = :action', {
+      action: AuditAction.PAYMENT_FAILED,
+    });
+  });
+
+  it('applies userId filter', async () => {
+    await controller.list({ page: 1, limit: 20, userId: 'u-1' });
+    expect(mockQb.andWhere).toHaveBeenCalledWith('a.actorId = :userId', { userId: 'u-1' });
+  });
+
+  it('applies paymentId filter', async () => {
+    await controller.list({ page: 1, limit: 20, paymentId: 'p-1' });
+    expect(mockQb.andWhere).toHaveBeenCalledWith('a.resourceId = :paymentId', { paymentId: 'p-1' });
+  });
+
+  it('applies provider filter', async () => {
+    await controller.list({ page: 1, limit: 20, provider: 'paystack' });
+    expect(mockQb.andWhere).toHaveBeenCalledWith("a.metadata->>'provider' = :provider", { provider: 'paystack' });
+  });
+
+  it('applies date range', async () => {
+    await controller.list({ page: 1, limit: 20, fromDate: '2026-07-01', toDate: '2026-07-31' });
+    expect(mockQb.andWhere).toHaveBeenCalledWith('a.createdAt >= :fromDate', { fromDate: new Date('2026-07-01') });
+    expect(mockQb.andWhere).toHaveBeenCalledWith('a.createdAt <= :toDate', { toDate: new Date('2026-07-31') });
+  });
+
+  it('applies search filter', async () => {
+    await controller.list({ page: 1, limit: 20, search: 'ERR' });
+    expect(mockQb.andWhere).toHaveBeenCalledWith(expect.stringContaining('ILIKE :search'), { search: '%ERR%' });
+  });
+});

--- a/backend/src/payments/payment-failure-logs.controller.ts
+++ b/backend/src/payments/payment-failure-logs.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { UserRole } from '../users/enums/userRoles.enum';
+import { ApiErrorDto } from '../common/dto/api-error.dto';
+import { AuditLog } from '../audit/entities/audit-log.entity';
+import { PaymentFailureQueryDto } from './dto/payment-failure-query.dto';
+import { paginatedResponse } from '../common/dto/pagination.dto';
+import { AuditAction } from '../audit/audit.service';
+
+@ApiTags('payments')
+@ApiBearerAuth('bearer')
+@ApiUnauthorizedResponse({ type: ApiErrorDto })
+@ApiForbiddenResponse({ type: ApiErrorDto })
+@UseGuards(RolesGuard)
+@Roles(UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+@Controller('payments/failure-logs')
+export class PaymentFailureLogsController {
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly auditRepository: Repository<AuditLog>,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'List payment failure logs (Staff/Admin only)' })
+  async list(@Query() query: PaymentFailureQueryDto) {
+    const { page, limit, userId, paymentId, provider, fromDate, toDate, search } = query;
+
+    const qb = this.auditRepository.createQueryBuilder('a');
+    qb.andWhere('a.action = :action', { action: AuditAction.PAYMENT_FAILED });
+
+    if (userId) qb.andWhere('a.actorId = :userId', { userId });
+    if (paymentId) qb.andWhere('a.resourceId = :paymentId', { paymentId });
+    if (provider) qb.andWhere("a.metadata->>'provider' = :provider", { provider });
+    if (fromDate) qb.andWhere('a.createdAt >= :fromDate', { fromDate: new Date(fromDate) });
+    if (toDate) qb.andWhere('a.createdAt <= :toDate', { toDate: new Date(toDate) });
+    if (search) {
+      qb.andWhere(
+        `(a.metadata->>'paymentReference' ILIKE :search
+          OR a.metadata->>'errorCode' ILIKE :search
+          OR a.metadata->>'errorMessage' ILIKE :search
+          OR CAST(a.metadata AS TEXT) ILIKE :search)`,
+        { search: `%${search}%` },
+      );
+    }
+
+    qb.orderBy('a.createdAt', 'DESC');
+    const total = await qb.getCount();
+    const items = await qb.skip((page - 1) * limit).take(limit).getMany();
+
+    return paginatedResponse('Payment failure logs retrieved successfully', items, total, page, limit);
+  }
+}

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -3,8 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './entities/payment.entity';
 import { Booking } from '../bookings/entities/booking.entity';
 import { User } from '../users/entities/user.entity';
+import { AuditLog } from '../audit/entities/audit-log.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
+import { PaymentFailureLogsController } from './payment-failure-logs.controller';
 import { PaystackProvider } from './providers/paystack.provider';
 import { SorobanEscrowProvider } from './providers/soroban-escrow.provider';
 import { InitializePaymentProvider } from './providers/initialize-payment.provider';
@@ -14,15 +16,17 @@ import { FindPaymentsProvider } from './providers/find-payments.provider';
 import { BookingsModule } from '../bookings/bookings.module';
 import { InvoicesModule } from '../invoices/invoices.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Payment, Booking, User]),
+    TypeOrmModule.forFeature([Payment, Booking, User, AuditLog]),
     BookingsModule,
     InvoicesModule,
     NotificationsModule,
+    AuditModule,
   ],
-  controllers: [PaymentsController],
+  controllers: [PaymentsController, PaymentFailureLogsController],
   providers: [
     PaymentsService,
     PaystackProvider,

--- a/backend/src/payments/providers/handle-webhook.provider.ts
+++ b/backend/src/payments/providers/handle-webhook.provider.ts
@@ -19,6 +19,8 @@ import { NotificationsService } from '../../notifications/notifications.service'
 import { NotificationType } from '../../notifications/enums/notification-type.enum';
 import { User } from '../../users/entities/user.entity';
 import { EmailService } from '../../email/email.service';
+import { AuditService } from '../../audit/audit.service';
+import { getCorrelationId } from '../../common/context/correlation-context';
 import { runInTransaction } from '../../common/utils/run-in-transaction';
 
 const LONG_TERM_PLANS = new Set([
@@ -50,6 +52,7 @@ export class HandleWebhookProvider {
     private readonly invoicesService: InvoicesService,
     private readonly notificationsService: NotificationsService,
     private readonly emailService: EmailService,
+    private readonly auditService: AuditService,
     private readonly configService: ConfigService,
     private readonly dataSource: DataSource,
   ) {}
@@ -187,6 +190,15 @@ export class HandleWebhookProvider {
     this.logger.log(
       `charge.success: payment ${payment.id} succeeded, booking ${payment.bookingId} confirmed`,
     );
+
+    this.auditService.paymentSuccess(payment.id, payment.userId, {
+      paymentReference: payment.providerReference,
+      amount: payment.amount,
+      currency: payment.currency,
+      provider: payment.provider,
+      bookingId: payment.bookingId,
+      correlationId: getCorrelationId(),
+    });
   }
 
   private async handleChargeFailed(reference: string): Promise<void> {
@@ -211,6 +223,17 @@ export class HandleWebhookProvider {
     });
 
     if (!payment) return;
+
+    this.auditService.paymentFailure(payment.id, payment.userId, {
+      paymentReference: payment.providerReference,
+      amount: payment.amount,
+      currency: payment.currency,
+      provider: payment.provider,
+      errorCode: 'CHARGE_FAILED',
+      errorMessage: 'Paystack charge.failed webhook received',
+      providerResponse: null,
+      correlationId: getCorrelationId(),
+    });
 
     this.usersRepository
       .findOne({ where: { id: payment.userId } })


### PR DESCRIPTION
## Summary

Adds structured logging for payment failure investigations.

### Changes
- Added payment-related audit action codes (PAYMENT_INITIATED, PAYMENT_SUCCESS, PAYMENT_FAILED, PAYMENT_REFUNDED, etc.)
- Added paymentFailure() and paymentSuccess() convenience methods to AuditService
- Updated HandleWebhookProvider to use AuditService for structured payment failure/success logging with correlation ID propagation
- Created PaymentFailureLogsController with filtering by userId, paymentId, provider, date range, and free-text search
- Created PaymentFailureQueryDto for query validation
- Updated PaymentsModule to import AuditModule and register new controller
- Added unit tests for AuditService payment actions and PaymentFailureLogsController

### Test Plan
- Unit tests for AuditService payment convenience methods
- Unit tests for PaymentFailureLogsController filtering and pagination