### PR TITLE
Feat/be 43 role permission matrix

### DIFF
--- a/backend/docs/ROLE_PERMISSIONS_MATRIX.md
+++ b/backend/docs/ROLE_PERMISSIONS_MATRIX.md
@@ -1,0 +1,24 @@
+# 🔐 Role-Permission Matrix Reference
+
+This document details the capability mapping across Global and Workspace-level roles in Oraculum.
+
+## 🌐 Global Roles
+
+| Permission | `SUPER_ADMIN` | `ADMIN` | `USER` |
+| :--- | :---: | :---: | :---: |
+| `manage:users` | ✅ | ✅ | ❌ |
+| `view:audit_logs` | ✅ | ✅ | ❌ |
+| `manage:system_settings` | ✅ | ❌ | ❌ |
+
+---
+
+## 🏢 Workspace Roles
+
+| Permission | `OWNER` | `ADMIN` | `MEMBER` | `GUEST` |
+| :--- | :---: | :---: | :---: | :---: |
+| `workspace:view` | ✅ | ✅ | ✅ | ✅ |
+| `workspace:member:invite` | ✅ | ✅ | ✅ | ❌ |
+| `workspace:member:remove` | ✅ | ✅ | ❌ | ❌ |
+| `workspace:update` | ✅ | ✅ | ❌ | ❌ |
+| `workspace:role:update` | ✅ | ❌ | ❌ | ❌ |
+| `workspace:delete` | ✅ | ❌ | ❌ | ❌ |

--- a/backend/src/auth/guard/permissions.guard.ts
+++ b/backend/src/auth/guard/permissions.guard.ts
@@ -1,0 +1,59 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PermissionsService } from '../permissions/permissions.service';
+import { Permission } from '../permissions/role-permissions.matrix';
+import { PERMISSIONS_KEY } from '../decorators/require-permissions.decorator';
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private permissionsService: PermissionsService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredPermissions = this.reflector.getAllAndOverride<Permission[]>(
+      PERMISSIONS_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredPermissions || requiredPermissions.length === 0) {
+      return true;
+    }
+
+    const { user, workspaceMember } = context.switchToHttp().getRequest();
+
+    if (!user) {
+      throw new ForbiddenException('User context not found.');
+    }
+
+    // Check Global Role first (Super Admin override)
+    const hasGlobalPermission = requiredPermissions.every((perm) =>
+      this.permissionsService.hasPermission(perm, user.globalRole),
+    );
+
+    if (hasGlobalPermission) {
+      return true;
+    }
+
+    // Fall back to Workspace Role evaluation if workspace member context is present
+    if (workspaceMember) {
+      const hasWorkspacePermission = requiredPermissions.every((perm) =>
+        this.permissionsService.hasPermission(perm, workspaceMember.role),
+      );
+
+      if (hasWorkspacePermission) {
+        return true;
+      }
+    }
+
+    throw new ForbiddenException(
+      'Insufficient permissions to perform this action.',
+    );
+  }
+}

--- a/backend/src/auth/permissions/permissions.service.spec.ts
+++ b/backend/src/auth/permissions/permissions.service.spec.ts
@@ -1,0 +1,47 @@
+import { PermissionsService } from './permissions.service';
+import { GlobalRole, WorkspaceRole, Permission } from './role-permissions.matrix';
+
+describe('PermissionsService (#51 BE-43)', () => {
+  let service: PermissionsService;
+
+  beforeEach(() => {
+    service = new PermissionsService();
+  });
+
+  describe('Global Role Evaluation', () => {
+    it('should grant SUPER_ADMIN all permissions', () => {
+      expect(
+        service.hasPermission(Permission.MANAGE_SYSTEM_SETTINGS, GlobalRole.SUPER_ADMIN),
+      ).toBe(true);
+      expect(
+        service.hasPermission(Permission.WORKSPACE_DELETE, GlobalRole.SUPER_ADMIN),
+      ).toBe(true);
+    });
+
+    it('should deny regular USER administrative actions', () => {
+      expect(
+        service.hasPermission(Permission.MANAGE_USERS, GlobalRole.USER),
+      ).toBe(false);
+    });
+  });
+
+  describe('Workspace Role Evaluation', () => {
+    it('should allow OWNER to delete workspace but deny MEMBER', () => {
+      expect(
+        service.hasPermission(Permission.WORKSPACE_DELETE, WorkspaceRole.OWNER),
+      ).toBe(true);
+      expect(
+        service.hasPermission(Permission.WORKSPACE_DELETE, WorkspaceRole.MEMBER),
+      ).toBe(false);
+    });
+
+    it('should allow MEMBER to invite users but deny GUEST', () => {
+      expect(
+        service.hasPermission(Permission.WORKSPACE_MEMBER_INVITE, WorkspaceRole.MEMBER),
+      ).toBe(true);
+      expect(
+        service.hasPermission(Permission.WORKSPACE_MEMBER_INVITE, WorkspaceRole.GUEST),
+      ).toBe(false);
+    });
+  });
+});

--- a/backend/src/auth/permissions/permissions.service.ts
+++ b/backend/src/auth/permissions/permissions.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import {
+  GlobalRole,
+  WorkspaceRole,
+  Permission,
+  GLOBAL_ROLE_PERMISSIONS,
+  WORKSPACE_ROLE_PERMISSIONS,
+} from './role-permissions.matrix';
+
+@Injectable()
+export class PermissionsService {
+  /**
+   * Checks if a global or workspace role grants a specific required permission.
+   */
+  hasPermission(
+    requiredPermission: Permission,
+    role: GlobalRole | WorkspaceRole,
+  ): boolean {
+    let allowedPermissions: Permission[] = [];
+
+    if (Object.values(GlobalRole).includes(role as GlobalRole)) {
+      allowedPermissions = GLOBAL_ROLE_PERMISSIONS[role as GlobalRole] || [];
+    } else if (Object.values(WorkspaceRole).includes(role as WorkspaceRole)) {
+      allowedPermissions = WORKSPACE_ROLE_PERMISSIONS[role as WorkspaceRole] || [];
+    }
+
+    return allowedPermissions.includes(requiredPermission);
+  }
+}

--- a/backend/src/auth/permissions/role-permissions.matrix.ts
+++ b/backend/src/auth/permissions/role-permissions.matrix.ts
@@ -1,0 +1,67 @@
+export enum GlobalRole {
+  SUPER_ADMIN = 'SUPER_ADMIN',
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+}
+
+export enum WorkspaceRole {
+  OWNER = 'OWNER',
+  ADMIN = 'ADMIN',
+  MEMBER = 'MEMBER',
+  GUEST = 'GUEST',
+}
+
+export enum Permission {
+  // System / Admin Permissions
+  MANAGE_USERS = 'manage:users',
+  VIEW_AUDIT_LOGS = 'view:audit_logs',
+  MANAGE_SYSTEM_SETTINGS = 'manage:system_settings',
+
+  // Workspace Permissions
+  WORKSPACE_DELETE = 'workspace:delete',
+  WORKSPACE_UPDATE = 'workspace:update',
+  WORKSPACE_MEMBER_INVITE = 'workspace:member:invite',
+  WORKSPACE_MEMBER_REMOVE = 'workspace:member:remove',
+  WORKSPACE_ROLE_UPDATE = 'workspace:role:update',
+  WORKSPACE_VIEW = 'workspace:view',
+}
+
+/**
+ * Explicit mapping of Global Roles to System Permissions
+ */
+export const GLOBAL_ROLE_PERMISSIONS: Record<GlobalRole, Permission[]> = {
+  [GlobalRole.SUPER_ADMIN]: Object.values(Permission),
+  [GlobalRole.ADMIN]: [
+    Permission.MANAGE_USERS,
+    Permission.VIEW_AUDIT_LOGS,
+    Permission.WORKSPACE_VIEW,
+  ],
+  [GlobalRole.USER]: [],
+};
+
+/**
+ * Explicit mapping of Workspace Roles to Workspace-level Permissions
+ */
+export const WORKSPACE_ROLE_PERMISSIONS: Record<WorkspaceRole, Permission[]> = {
+  [WorkspaceRole.OWNER]: [
+    Permission.WORKSPACE_DELETE,
+    Permission.WORKSPACE_UPDATE,
+    Permission.WORKSPACE_MEMBER_INVITE,
+    Permission.WORKSPACE_MEMBER_REMOVE,
+    Permission.WORKSPACE_ROLE_UPDATE,
+    Permission.WORKSPACE_VIEW,
+  ],
+  [WorkspaceRole.ADMIN]: [
+    Permission.WORKSPACE_UPDATE,
+    Permission.WORKSPACE_MEMBER_INVITE,
+    Permission.WORKSPACE_MEMBER_REMOVE,
+    Permission.WORKSPACE_VIEW,
+  ],
+  [WorkspaceRole.MEMBER]: [
+    Permission.WORKSPACE_MEMBER_INVITE,
+    Permission.WORKSPACE_VIEW,
+  ],
+  [WorkspaceRole.GUEST]: [
+    Permission.WORKSPACE_VIEW,
+  ],
+};

--- a/backend/src/common/dto/audit-log-query.dto.ts
+++ b/backend/src/common/dto/audit-log-query.dto.ts
@@ -1,0 +1,36 @@
+import { IsOptional, IsString, IsEnum, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum AuditAction {
+  USER_BAN = 'USER_BAN',
+  USER_UNBAN = 'USER_UNBAN',
+  CONTENT_DELETE = 'CONTENT_DELETE',
+  ROLE_UPDATE = 'ROLE_UPDATE',
+}
+
+export class AuditLogQueryDto {
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+
+  @IsOptional()
+  @IsString()
+  targetId?: string;
+
+  @IsOptional()
+  @IsEnum(AuditAction)
+  action?: AuditAction;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/common/services/audit-log.service.ts
+++ b/backend/src/common/services/audit-log.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AuditLogEntity } from '../entities/audit-log.entity';
+import { AuditLogQueryDto } from '../dto/audit-log-query.dto';
+
+@Injectable()
+export class AuditLogService {
+  constructor(
+    @InjectRepository(AuditLogEntity)
+    private readonly auditLogRepo: Repository<AuditLogEntity>,
+  ) {}
+
+  async logAction(actorId: string, targetId: string, action: string, details?: Record<string, any>) {
+    const entry = this.auditLogRepo.create({
+      actorId,
+      targetId,
+      action,
+      details,
+      createdAt: new Date(),
+    });
+    return this.auditLogRepo.save(entry);
+  }
+
+  async getAuditLogs(query: AuditLogQueryDto) {
+    const { actorId, targetId, action, page = 1, limit = 20 } = query;
+    const qb = this.auditLogRepo.createQueryBuilder('audit');
+
+    if (actorId) {
+      qb.andWhere('audit.actorId = :actorId', { actorId });
+    }
+    if (targetId) {
+      qb.andWhere('audit.targetId = :targetId', { targetId });
+    }
+    if (action) {
+      qb.andWhere('audit.action = :action', { action });
+    }
+
+    qb.orderBy('audit.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+}

--- a/backend/src/notifications/services/webhook.service.ts
+++ b/backend/src/notifications/services/webhook.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { lastValueFrom } from 'rxjs';
+
+export interface WebhookPayload {
+  eventId: string;
+  eventType: string;
+  data: Record<string, any>;
+}
+
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
+  constructor(private readonly httpService: HttpService) {}
+
+  validatePayload(payload: WebhookPayload): void {
+    if (!payload || !payload.eventId || !payload.eventType || !payload.data) {
+      throw new BadRequestException('Malformed webhook payload: missing required fields');
+    }
+  }
+
+  async dispatchWithRetry(
+    targetUrl: string,
+    payload: WebhookPayload,
+    maxRetries: number = 3,
+    initialDelayMs: number = 100,
+  ): Promise<boolean> {
+    this.validatePayload(payload);
+
+    let attempt = 0;
+    let delay = initialDelayMs;
+
+    while (attempt < maxRetries) {
+      try {
+        attempt++;
+        const response = await lastValueFrom(
+          this.httpService.post(targetUrl, payload, { timeout: 5000 }),
+        );
+
+        if (response.status >= 200 && response.status < 300) {
+          return true;
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Webhook delivery failed to ${targetUrl} (Attempt ${attempt}/${maxRetries}): ${error.message}`,
+        );
+
+        if (attempt >= maxRetries) {
+          throw new Error(`Webhook delivery failed after ${maxRetries} attempts`);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        delay *= 2; // Exponential backoff
+      }
+    }
+
+    return false;
+  }
+}

--- a/backend/src/users/admin-audit.controller.spec.ts
+++ b/backend/src/users/admin-audit.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminAuditController } from './admin-audit.controller';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import { AuditAction } from '../../common/dto/audit-log-query.dto';
+
+describe('AdminAuditController', () => {
+  let controller: AdminAuditController;
+  let service: AuditLogService;
+
+  const mockAuditService = {
+    getAuditLogs: jest.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'log-1',
+          actorId: 'admin-123',
+          targetId: 'user-456',
+          action: AuditAction.USER_BAN,
+          createdAt: new Date(),
+        },
+      ],
+      meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminAuditController],
+      providers: [
+        {
+          provide: AuditLogService,
+          useValue: mockAuditService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminAuditController>(AdminAuditController);
+    service = module.get<AuditLogService>(AuditLogService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return audit records with applied filters', async () => {
+    const query = { actorId: 'admin-123', action: AuditAction.USER_BAN };
+    const result = await controller.getAuditLogs(query);
+
+    expect(service.getAuditLogs).toHaveBeenCalledWith(query);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].action).toEqual(AuditAction.USER_BAN);
+  });
+});

--- a/backend/src/users/admin-audit.controller.ts
+++ b/backend/src/users/admin-audit.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { UserRole } from '../../users/enums/user-role.enum';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import { AuditLogQueryDto } from '../../common/dto/audit-log-query.dto';
+
+@Controller('admin/audit-logs')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+export class AdminAuditController {
+  constructor(private readonly auditLogService: AuditLogService) {}
+
+  @Get()
+  async getAuditLogs(@Query() query: AuditLogQueryDto) {
+    return this.auditLogService.getAuditLogs(query);
+  }
+}

--- a/backend/test/webhook-handler.spec.ts
+++ b/backend/test/webhook-handler.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { BadRequestException } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import { WebhookService, WebhookPayload } from '../src/notifications/services/webhook.service';
+
+describe('WebhookService & Retry Behavior (BE-48)', () => {
+  let service: WebhookService;
+  let httpService: HttpService;
+
+  const validPayload: WebhookPayload = {
+    eventId: 'evt_12345',
+    eventType: 'USER_MODERATED',
+    data: { userId: 'usr_789', action: 'BAN' },
+  };
+
+  const targetUrl = 'https://example.com/webhook';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookService,
+        {
+          provide: HttpService,
+          useValue: {
+            post: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhookService>(WebhookService);
+    httpService = module.get<HttpService>(HttpService);
+  });
+
+  describe('Payload Validation', () => {
+    it('should throw BadRequestException for malformed or incomplete payload', () => {
+      const invalidPayload = { eventId: 'evt_123' } as any;
+
+      expect(() => service.validatePayload(invalidPayload)).toThrow(BadRequestException);
+      expect(() => service.validatePayload(null as any)).toThrow(BadRequestException);
+    });
+
+    it('should pass validation for valid payload structure', () => {
+      expect(() => service.validatePayload(validPayload)).not.toThrow();
+    });
+  });
+
+  describe('Dispatch & Retry Logic', () => {
+    it('should successfully deliver webhook on first attempt', async () => {
+      const mockResponse: AxiosResponse = {
+        data: { received: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      };
+
+      jest.spyOn(httpService, 'post').mockReturnValue(of(mockResponse));
+
+      const result = await service.dispatchWithRetry(targetUrl, validPayload, 3, 10);
+
+      expect(result).toBe(true);
+      expect(httpService.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry on failure and succeed if subsequent attempt passes', async () => {
+      const mockResponse: AxiosResponse = {
+        data: { received: true },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      };
+
+      jest
+        .spyOn(httpService, 'post')
+        .mockReturnValueOnce(throwError(() => new Error('Network Timeout')))
+        .mockReturnValueOnce(of(mockResponse));
+
+      const result = await service.dispatchWithRetry(targetUrl, validPayload, 3, 10);
+
+      expect(result).toBe(true);
+      expect(httpService.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail after reaching maximum retry limit on persistent errors', async () => {
+      jest
+        .spyOn(httpService, 'post')
+        .mockReturnValue(throwError(() => new Error('500 Internal Server Error')));
+
+      await expect(
+        service.dispatchWithRetry(targetUrl, validPayload, 3, 10),
+      ).rejects.toThrow('Webhook delivery failed after 3 attempts');
+
+      expect(httpService.post).toHaveBeenCalledTimes(3);
+    });
+  });
+});


### PR DESCRIPTION
# Overview
Closes  #51

Establishes an explicit, auditable role-permission matrix governing authorization across global system admins and workspace collaborators:
* Centralized permission lookup table mapping permissions (`Permission`) to `GlobalRole` and `WorkspaceRole`.
* Implemented `PermissionsGuard` and `PermissionsService` to consistently deny unsupported actions.
* Added complete developer matrix documentation at `docs/ROLE_PERMISSIONS_MATRIX.md`.

---

## 🛠️ Key Architectural Changes

### 1. Matrix Definitions (`backend/src/auth/permissions/role-permissions.matrix.ts`)
* Defined `GlobalRole`, `WorkspaceRole`, and `Permission` enums alongside permission lookup maps (`GLOBAL_ROLE_PERMISSIONS`, `WORKSPACE_ROLE_PERMISSIONS`).

### 2. Authorization Layer (`backend/src/auth/guards/permissions.guard.ts`)
* Implemented runtime guard resolving global and workspace member scopes dynamically.

---

## 🧪 Testing & Verification

```bash
npm run test backend/src/auth/permissions/permissions.service.spec.ts