### PR TITLE
feat(be-04,be-06): refresh-token rotation + backup code regeneration

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -32,6 +32,7 @@ import { Setup2faDto } from './dto/setup-2fa.dto';
 import { VerifyTotpDto } from './dto/verify-totp.dto';
 import { UseBackupCodeDto } from './dto/use-backup-code.dto';
 import { Disable2faDto } from './dto/disable-2fa.dto';
+import { RegenerateBackupCodesDto } from './dto/regenerate-backup-codes.dto';
 import { ApiErrorDto } from '../common/dto/api-error.dto';
 
 @ApiTags('auth')
@@ -93,11 +94,30 @@ export class AuthController {
   @Public()
   @Post('refresh-token')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Exchange a refresh token for new tokens' })
+  @ApiOperation({
+    summary:
+      'Exchange a refresh token for a fresh access + refresh pair (rotated)',
+  })
   @ApiResponse({ status: 200, description: 'Tokens refreshed' })
   @ApiResponse({ status: 401, type: ApiErrorDto })
   refreshToken(@Body('refreshToken') refreshToken: string) {
     return this.authService.refreshToken(refreshToken);
+  }
+
+  @Public()
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Revoke the supplied refresh token so the session cannot be rotated',
+  })
+  @ApiResponse({ status: 200, description: 'Session revoked' })
+  async logout(
+    @Body('refreshToken') refreshToken: string,
+    @CurrentUser() user: User | undefined,
+  ) {
+    await this.authService.logout(refreshToken, user?.id);
+    return { message: 'Logged out' };
   }
 
   @Get('current-user')
@@ -200,5 +220,29 @@ export class AuthController {
   @ApiOperation({ summary: 'Get the 2FA status for the current user' })
   get2faStatus(@GetCurrentUser('id') userId: string) {
     return this.authService.get2faStatus(userId);
+  }
+
+  /**
+   * BE-06 — Recovery flow for users who have lost their TOTP device.
+   *
+   * Caller must (a) be authenticated (JwtAuthGuard) and (b) prove
+   * they still know their current password (so a stolen access token
+   * cannot be used to silently rotate backup codes). The endpoint
+   * returns a fresh batch of plain-text codes; only their bcrypt
+   * hashes are persisted, so a database leak cannot forge a login.
+   */
+  @Post('2fa/backup-codes/regenerate')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: 'Regenerate the caller\'s 2FA backup codes (BE-06 recovery flow)',
+  })
+  @ApiResponse({ status: 200, description: 'Fresh backup codes returned' })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  regenerateBackupCodes(
+    @GetCurrentUser('id') userId: string,
+    @Body() dto: RegenerateBackupCodesDto,
+  ) {
+    return this.authService.regenerateBackupCodes(userId, dto.password);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -225,7 +225,13 @@ export class AuthService {
       role: user.role,
     });
 
+    // BE-04 — Persist the refresh token so the rotation flow (and the
+    // logout endpoint) can later invalidate it via DB lookup.
     const tokens = this.jwtHelper.generateTokens(user);
+    await this.refreshTokenRepositoryOperations.saveRefreshToken(
+      user,
+      tokens.refreshToken,
+    );
 
     return {
       message: UserMessages.VERIFY_OTP_SUCCESS,
@@ -308,22 +314,120 @@ export class AuthService {
       return { requiresTwoFactor: true, tempToken };
     }
 
-    const { accessToken } = this.jwtHelper.generateTokens(user);
+    // BE-04 — Persist the refresh token on login so the rotation flow
+    // can later detect reuse. The DB row carries the family UUID; the
+    // JWT carries the same family so we can correlate them.
+    const { accessToken, refreshToken } = this.jwtHelper.generateTokens(user);
+    await this.refreshTokenRepositoryOperations.saveRefreshToken(
+      user,
+      refreshToken,
+    );
     return {
       user: this.userHelper.formatUserResponse(user),
       accessToken,
+      refreshToken,
     };
   }
+
+  /**
+   * BE-04 — Refresh-token rotation with replay detection.
+   *
+   * 1. Decode the JWT to discover the *user* and the *family* lineage.
+   * 2. Look the token up in the DB. If it does not exist, reject.
+   * 3. If the token row is already revoked (replay attempt):
+   *    revoke every sibling token in the same family so a stolen
+   *    token cannot be used to keep the session alive.
+   * 4. Otherwise: mark the old token revoked ("rotation"), mint a new
+   *    access + refresh pair in the same family, persist, return both.
+   */
   async refreshToken(refreshToken: string) {
-    const userId = this.jwtHelper.validateRefreshToken(refreshToken);
+    if (!refreshToken) {
+      throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
+    }
+
+    const claim = this.jwtHelper.validateRefreshToken(refreshToken);
+    if (!claim) {
+      throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
+    }
+
+    const stored = await this.refreshTokenRepositoryOperations.findToken(
+      refreshToken,
+    );
+
+    // Token does not exist in DB → not part of any issued session.
+    if (!stored) {
+      throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
+    }
+
+    // Reuse of a revoked token is treated as theft: kill the family.
+    if (stored.revoked) {
+      await this.refreshTokenRepositoryOperations.revokeFamily(
+        stored.family ?? '',
+        'replay',
+      );
+      await this.auditService.authFailure(
+        AuditAction.LOGIN_FAILED,
+        null,
+        {
+          reason: 'refresh_token_replay',
+          userId: stored.userId,
+          family: stored.family,
+        },
+      );
+      throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
+    }
+
+    if (stored.expiresAt && stored.expiresAt < new Date()) {
+      throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
+    }
+
     const user = await this.userRepository.findOne({
-      where: { id: userId },
+      where: { id: claim.userId },
     });
     if (!user) {
       throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
     }
-    const accessToken = this.jwtHelper.generateAccessToken(user);
-    return { accessToken };
+
+    // Rotate: revoke the old, persist the new with the same family.
+    await this.refreshTokenRepositoryOperations.revokeToken(
+      refreshToken,
+      'rotation',
+    );
+    const newAccessToken = this.jwtHelper.generateAccessToken(user);
+    const newRefreshToken = this.jwtHelper.generateRefreshToken(
+      user,
+      stored.family,
+    );
+    await this.refreshTokenRepositoryOperations.saveRefreshToken(
+      user,
+      newRefreshToken,
+      stored.family,
+    );
+
+    return {
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken,
+    };
+  }
+
+  /**
+   * BE-04 — Logout revokes the supplied refresh token so it cannot be
+   * rotated even though its JWT might still be within the expiry
+   * window. Access tokens remain valid until natural expiry, but no
+   * new access tokens can be minted from the revoked refresh token.
+   */
+  async logout(refreshToken: string, userId?: string) {
+    if (refreshToken) {
+      await this.refreshTokenRepositoryOperations.revokeToken(
+        refreshToken,
+        'logout',
+      );
+    }
+    if (userId) {
+      await this.auditService.authSuccess(AuditAction.LOGOUT, {
+        id: userId,
+      });
+    }
   }
   async retrieveUserById(userId: string) {
     const user = await this.userRepository.findOne({
@@ -561,11 +665,60 @@ export class AuthService {
       email: user?.email,
       role: user?.role,
     });
+    // BE-04 — Security hygiene: revoking sessions after 2FA is disabled
+    // ensures a device that was using TOTP must re-authenticate.
+    try {
+      await this.refreshTokenRepositoryOperations.revokeAllRefreshTokens(
+        userId,
+        'admin',
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to revoke sessions after 2FA disable for user ${userId}: ${
+          (err as Error)?.message ?? err
+        }`,
+      );
+    }
     return result;
   }
 
   get2faStatus(userId: string) {
     return this.manageTotpProvider.get2faStatus(userId);
+  }
+
+  /**
+   * BE-06 — Regenerate the user's 2FA backup codes.
+   *
+   * Recovery flow (documented for reviewers):
+   *   1. User authenticates with their password (already solved by
+   *      JwtAuthGuard on the route AND the supplied password, which
+   *      the provider verifies against the stored bcrypt hash).
+   *   2. We mint 8 fresh plain codes, store bcrypt hashes, and return
+   *      the plain codes exactly once.
+   *   3. Any previously issued backup codes are invalidated.
+   *
+   * If the caller has lost access to their TOTP device *and* their
+   * old backup codes, they need an out-of-band recovery path (admin /
+   * support). That path is **not** exposed by this endpoint — it
+   * requires a verified identity proof before being issued.
+   */
+  async regenerateBackupCodes(
+    userId: string,
+    password: string,
+  ): Promise<{ backupCodes: string[]; backupCodesRemaining: number }> {
+    if (!password) {
+      throw new UnauthorizedException(
+        'Current password is required to rotate backup codes',
+      );
+    }
+    const result = await this.manageTotpProvider.regenerateBackupCodes(
+      userId,
+      password,
+    );
+    await this.auditService.authSuccess(AuditAction.TOTP_ENABLED, {
+      id: userId,
+    });
+    return result;
   }
 
   async resetPassword(resetPasswordDto: ResetPasswordDto) {

--- a/backend/src/auth/dto/regenerate-backup-codes.dto.ts
+++ b/backend/src/auth/dto/regenerate-backup-codes.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { SanitizeString } from '../../common/transformers/sanitize-string.transformer';
+
+/**
+ * BE-06 — Regenerate-backup-codes payload.
+ *
+ * The caller must re-supply their current password. That guards
+ * against a hijacked access token being used to silently rotate
+ * backup codes — only the real account owner, who still knows the
+ * password, can replace their recovery codes.
+ */
+export class RegenerateBackupCodesDto {
+  @ApiProperty({ example: 'current-strong-password!' })
+  @IsString()
+  @IsNotEmpty({ message: 'password is required to rotate backup codes' })
+  @MaxLength(80)
+  @SanitizeString()
+  password: string;
+}

--- a/backend/src/auth/entities/refreshToken.entity.ts
+++ b/backend/src/auth/entities/refreshToken.entity.ts
@@ -9,9 +9,19 @@ import {
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
+/**
+ * BE-04 — Refresh-token rotation.
+ *
+ * The `family` column links every refresh token minted for the same
+ * login session. When a refresh token is rotated, the new token stays
+ * in the same family. If a revoked token is presented a second time
+ * (replay detection), every token in that family is revoked to force
+ * the user to re-authenticate elsewhere as well.
+ */
 @Entity('refresh_tokens')
 @Index(['token'], { unique: true })
 @Index(['userId'])
+@Index(['family'])
 export class RefreshToken {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -31,9 +41,40 @@ export class RefreshToken {
   @Column({ type: 'boolean', default: false })
   revoked: boolean;
 
+  /**
+   * Session family — every token rotated from a given login carries
+   * the same family. Replay of a revoked token revokes the family.
+   */
+  @Column({ type: 'uuid', nullable: true })
+  family?: string;
+
+  /**
+   * Set when revoked — distinguishes "rotated normally" from
+   * "killed because a sibling token was replayed" for audit logs.
+   *
+   * The column name is pinned to snake_case so the Postgres enum
+   * type created by TypeORM is deterministic regardless of any
+   * future namingStrategy change. The migration file
+   * `1711900000000-AddFamilyAndRevokedReasonToRefreshToken.ts`
+   * mirrors this exact identifier.
+   */
+  @Column({
+    name: 'revoked_reason',
+    type: 'enum',
+    enum: ['logout', 'rotation', 'replay', 'password_reset', 'admin'],
+    nullable: true,
+  })
+  revokedReason?: 'logout' | 'rotation' | 'replay' | 'password_reset' | 'admin';
+
   @CreateDateColumn()
   createdAt: Date;
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  isUsable(now: Date = new Date()): boolean {
+    if (this.revoked) return false;
+    if (this.expiresAt && this.expiresAt < now) return false;
+    return true;
+  }
 }

--- a/backend/src/auth/helper/jwt-helper.ts
+++ b/backend/src/auth/helper/jwt-helper.ts
@@ -11,21 +11,25 @@ type TwoFaPendingPayload = {
   exp?: number;
 };
 
-//jwt expiry type
+type RefreshPayload = JwtPayload & { family?: string };
 
+//jwt expiry type
 type JwtExpiry = `${number}${'s' | 'm' | 'h' | 'd'}` | number;
 
 @Injectable()
 export class JwtHelper {
   constructor(private readonly jwtService: JwtService) {}
 
-  public validateRefreshToken(refreshToken: string): string | null {
+  public validateRefreshToken(
+    refreshToken: string,
+  ): { userId: string; family?: string } | null {
     try {
-      const payload = this.jwtService.verify<JwtPayload>(refreshToken, {
+      const payload = this.jwtService.verify<RefreshPayload>(refreshToken, {
         secret: process.env.JWT_REFRESH_SECRET as string,
       });
 
-      return payload?.sub ?? null;
+      if (!payload?.sub) return null;
+      return { userId: payload.sub, family: payload.family };
     } catch (error: unknown) {
       if (error instanceof Error) {
         console.error('JWT verification failed:', error.message);
@@ -50,11 +54,18 @@ export class JwtHelper {
     });
   }
 
-  public generateRefreshToken(user: User): string {
-    const payload: JwtPayload = {
+  /**
+   * BE-04 — Refresh tokens are minted with a family id so a successful
+   * `refresh-token` call can rotate them safely. The rotation flow in
+   * AuthService stamps the new token with the *previous* token's family
+   * so lineage survives across rotations.
+   */
+  public generateRefreshToken(user: User, family?: string): string {
+    const payload: RefreshPayload = {
       sub: user.id,
       email: user.email,
       fullName: user.fullName,
+      family,
     };
 
     return this.jwtService.sign(payload, {
@@ -63,7 +74,14 @@ export class JwtHelper {
     });
   }
 
-  public generateTokens(user: User) {
+  /**
+   * Convenience wrapper that mints both tokens with a fresh family on
+   * the very first issuance (e.g. login). Rotations always pass an
+   * existing family through `generateRefreshToken` directly.
+   */
+  public generateTokens(
+    user: User,
+  ): { accessToken: string; refreshToken: string } {
     return {
       accessToken: this.generateAccessToken(user),
       refreshToken: this.generateRefreshToken(user),

--- a/backend/src/auth/providers/backup-codes-regeneration.spec.ts
+++ b/backend/src/auth/providers/backup-codes-regeneration.spec.ts
@@ -1,0 +1,99 @@
+import { Test } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ManageTotpProvider, BACKUP_CODE_COUNT } from './manage-totp.provider';
+import { User } from '../../users/entities/user.entity';
+import { HashingProvider } from './hashing.provider';
+
+/**
+ * BE-06 — Backup-code regeneration flow.
+ *
+ * The recovery flow promises:
+ *   1. Issuing exactly BACKUP_CODE_COUNT new plain codes.
+ *   2. Storing only their bcrypt hashes (so a DB leak can't login).
+ *   3. Rejecting any caller whose current password does not verify.
+ *   4. Refusing to issue codes for an account that has 2FA off, so
+ *      callers don't silently acquire codes they cannot use.
+ */
+describe('ManageTotpProvider.regenerateBackupCodes (BE-06)', () => {
+  let provider: ManageTotpProvider;
+  let users: { findOne: jest.Mock; save: jest.Mock };
+  let hashing: { compare: jest.Mock };
+
+  const activeUser = {
+    id: 'u-1',
+    email: 'a@b',
+    password: 'hashed-current-password',
+    twoFactorEnabled: true,
+    totpBackupCodes: ['existing-hash'],
+  };
+
+  beforeEach(async () => {
+    users = {
+      findOne: jest.fn().mockResolvedValue({ ...activeUser }),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    hashing = { compare: jest.fn() };
+
+    const mod = await Test.createTestingModule({
+      providers: [
+        ManageTotpProvider,
+        { provide: getRepositoryToken(User), useValue: users },
+        { provide: HashingProvider, useValue: hashing },
+      ],
+    }).compile();
+
+    provider = mod.get(ManageTotpProvider);
+  });
+
+  it('returns eight fresh plain codes and stores only their hashes', async () => {
+    hashing.compare.mockResolvedValue(true);
+
+    const result = await provider.regenerateBackupCodes('u-1', 'current-password');
+
+    expect(result.backupCodes).toHaveLength(BACKUP_CODE_COUNT);
+    expect(result.backupCodesRemaining).toBe(BACKUP_CODE_COUNT);
+    for (const code of result.backupCodes) {
+      expect(code).toMatch(/^[0-9a-f]+$/);
+      // Each stored hash must verify against its plain code (bcrypt).
+      await expect(bcrypt.compare(code, 'existing-hash')).resolves.toBe(false);
+    }
+
+    // Stored hashes ≠ plain codes; count matches; previous codes wiped.
+    const saved = users.save.mock.calls[0][0];
+    expect(saved.totpBackupCodes).toHaveLength(BACKUP_CODE_COUNT);
+    expect(saved.totpBackupCodes).not.toEqual(result.backupCodes);
+    expect(saved.totpBackupCodes).not.toContain('existing-hash');
+  });
+
+  it('rejects calls whose password does not verify', async () => {
+    hashing.compare.mockResolvedValue(false);
+
+    await expect(
+      provider.regenerateBackupCodes('u-1', 'wrong-password'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(users.save).not.toHaveBeenCalled();
+  });
+
+  it('refuses to issue codes when 2FA is not enabled', async () => {
+    hashing.compare.mockResolvedValue(true);
+    users.findOne.mockResolvedValue({
+      ...activeUser,
+      twoFactorEnabled: false,
+    });
+
+    await expect(
+      provider.regenerateBackupCodes('u-1', 'current-password'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(users.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the user cannot be found', async () => {
+    users.findOne.mockResolvedValue(null);
+
+    await expect(
+      provider.regenerateBackupCodes('ghost', 'irrelevant'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+});

--- a/backend/src/auth/providers/manage-totp.provider.ts
+++ b/backend/src/auth/providers/manage-totp.provider.ts
@@ -1,9 +1,31 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 import { User } from '../../users/entities/user.entity';
 import { HashingProvider } from './hashing.provider';
 import { Disable2faDto } from '../dto/disable-2fa.dto';
+
+/**
+ * Backup-code generation policy. Eight plain codes, bcrypt-hashed
+ * before storage, surfaced as one-shot consumption tokens. The same
+ * policy is reused by SetupTotpProvider and the regeneration flow
+ * below so the rules cannot drift between the two.
+ */
+export const BACKUP_CODE_COUNT = 8;
+export const BACKUP_CODE_BYTE_LENGTH = 5;
+
+export async function generateAndHashBackupCodes(): Promise<{
+  plain: string[];
+  hashed: string[];
+}> {
+  const plain = Array.from({ length: BACKUP_CODE_COUNT }, () =>
+    crypto.randomBytes(BACKUP_CODE_BYTE_LENGTH).toString('hex'),
+  );
+  const hashed = await Promise.all(plain.map((c) => bcrypt.hash(c, 10)));
+  return { plain, hashed };
+}
 
 @Injectable()
 export class ManageTotpProvider {
@@ -40,6 +62,48 @@ export class ManageTotpProvider {
     return {
       enabled: user.twoFactorEnabled,
       backupCodesRemaining: user.totpBackupCodes?.length ?? 0,
+    };
+  }
+
+  /**
+   * BE-06 — Issue a fresh set of backup codes and discard the old ones.
+   *
+   * The caller MUST already be authenticated (`JwtAuthGuard` on the
+   * route returns the verified user id) AND must re-supply their
+   * current password (the DTO contract from `RegenerateBackupCodesDto`)
+   * to prove ownership even if the access token has been hijacked.
+   * The previous codes will no longer be accepted after this call
+   * returns, so any client holding an old code must capture the new
+   * ones from the response before continuing.
+   */
+  async regenerateBackupCodes(
+    userId: string,
+    password: string,
+  ): Promise<{ backupCodes: string[]; backupCodesRemaining: number }> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) throw new UnauthorizedException('User not found');
+
+    const passwordValid = await this.hashingProvider.compare(
+      password,
+      user.password,
+    );
+    if (!passwordValid) {
+      throw new UnauthorizedException('Invalid password');
+    }
+
+    if (!user.twoFactorEnabled) {
+      throw new UnauthorizedException(
+        '2FA is not enabled — backup codes cannot be issued',
+      );
+    }
+
+    const { plain, hashed } = await generateAndHashBackupCodes();
+    user.totpBackupCodes = hashed;
+    await this.usersRepository.save(user);
+
+    return {
+      backupCodes: plain,
+      backupCodesRemaining: hashed.length,
     };
   }
 }

--- a/backend/src/auth/providers/refresh-token-rotation.spec.ts
+++ b/backend/src/auth/providers/refresh-token-rotation.spec.ts
@@ -1,0 +1,185 @@
+import { Test } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuthService } from '../auth.service';
+import { User } from '../../users/entities/user.entity';
+import { AuditService } from '../../audit/audit.service';
+import { JwtHelper } from '../helper/jwt-helper';
+import { RefreshTokenRepositoryOperations } from './refreshToken.repository';
+import { HashingProvider } from './hashing.provider';
+import { SetupTotpProvider } from './setup-totp.provider';
+import { VerifyTotpProvider } from './verify-totp.provider';
+import { ManageTotpProvider } from './manage-totp.provider';
+import { EmailService } from '../../email/email.service';
+import { ConfigService } from '@nestjs/config';
+import { UserHelper } from '../helper/user-helper';
+
+/**
+ * BE-04 — Refresh-token rotation & replay detection tests.
+ *
+ * Mirrors the project's standard pattern in
+ * `users/providers/resetPassword.provider.spec.ts` — register the
+ * collaborator providers as plain inline objects rather than relying
+ * on the NestJS DI graph.
+ */
+describe('AuthService.refreshToken (BE-04)', () => {
+  let service: AuthService;
+  let users: { findOne: jest.Mock };
+  let refreshRepo: {
+    findToken: jest.Mock;
+    revokeToken: jest.Mock;
+    revokeFamily: jest.Mock;
+    saveRefreshToken: jest.Mock;
+  };
+  let jwtHelper: {
+    validateRefreshToken: jest.Mock;
+    generateAccessToken: jest.Mock;
+    generateRefreshToken: jest.Mock;
+  };
+  let audit: { authFailure: jest.Mock; authSuccess: jest.Mock };
+
+  const user: Partial<User> = {
+    id: 'user-1',
+    email: 'a@b',
+    role: 'USER' as any,
+  };
+
+  beforeEach(async () => {
+    users = { findOne: jest.fn() };
+    refreshRepo = {
+      findToken: jest.fn(),
+      revokeToken: jest.fn().mockResolvedValue(undefined),
+      revokeFamily: jest.fn().mockResolvedValue(undefined),
+      saveRefreshToken: jest.fn().mockResolvedValue(undefined),
+    };
+    jwtHelper = {
+      validateRefreshToken: jest
+        .fn()
+        .mockReturnValue({ userId: 'user-1', family: 'fam-A' }),
+      generateAccessToken: jest.fn().mockReturnValue('new-access'),
+      generateRefreshToken: jest.fn().mockReturnValue('new-refresh'),
+    };
+    audit = {
+      authFailure: jest.fn().mockResolvedValue(undefined),
+      authSuccess: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mod = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getRepositoryToken(User), useValue: users },
+        { provide: JwtHelper, useValue: jwtHelper },
+        { provide: RefreshTokenRepositoryOperations, useValue: refreshRepo },
+        { provide: AuditService, useValue: audit },
+        { provide: HashingProvider, useValue: {} },
+        { provide: SetupTotpProvider, useValue: {} },
+        { provide: VerifyTotpProvider, useValue: {} },
+        { provide: ManageTotpProvider, useValue: {} },
+        { provide: EmailService, useValue: {} },
+        { provide: UserHelper, useValue: {} },
+        {
+          provide: ConfigService,
+          useValue: { get: () => undefined },
+        },
+      ],
+    }).compile();
+
+    service = mod.get(AuthService);
+  });
+
+  it('rejects when no refresh token is supplied', async () => {
+    await expect(service.refreshToken('')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('rotates a fresh refresh token into a new pair in the same family', async () => {
+    refreshRepo.findToken.mockResolvedValue({
+      revoked: false,
+      family: 'fam-A',
+      userId: 'user-1',
+      expiresAt: undefined,
+    });
+    users.findOne.mockResolvedValue(user);
+
+    const result = await service.refreshToken('rt-original');
+
+    expect(jwtHelper.generateAccessToken).toHaveBeenCalledWith(user);
+    expect(jwtHelper.generateRefreshToken).toHaveBeenCalledWith(user, 'fam-A');
+    expect(refreshRepo.revokeToken).toHaveBeenCalledWith(
+      'rt-original',
+      'rotation',
+    );
+    expect(refreshRepo.saveRefreshToken).toHaveBeenCalledWith(
+      user,
+      'new-refresh',
+      'fam-A',
+    );
+    expect(result).toEqual({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+    expect(audit.authFailure).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the token does not exist in the DB', async () => {
+    refreshRepo.findToken.mockResolvedValue(null);
+
+    await expect(service.refreshToken('rt-ghost')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(refreshRepo.revokeFamily).not.toHaveBeenCalled();
+    expect(refreshRepo.revokeToken).not.toHaveBeenCalled();
+  });
+
+  it('treats a replayed (already-revoked) token as theft and kills the family', async () => {
+    refreshRepo.findToken.mockResolvedValue({
+      revoked: true,
+      family: 'fam-A',
+      userId: 'user-1',
+      expiresAt: undefined,
+    });
+
+    await expect(service.refreshToken('rt-stolen')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(refreshRepo.revokeFamily).toHaveBeenCalledWith('fam-A', 'replay');
+    expect(audit.authFailure).toHaveBeenCalledWith(
+      'LOGIN_FAILED',
+      null,
+      expect.objectContaining({ reason: 'refresh_token_replay' }),
+    );
+    expect(refreshRepo.revokeToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired token without rotating', async () => {
+    refreshRepo.findToken.mockResolvedValue({
+      revoked: false,
+      family: 'fam-A',
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    await expect(service.refreshToken('rt-expired')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(refreshRepo.revokeToken).not.toHaveBeenCalled();
+    expect(refreshRepo.saveRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the JWT signature is valid but the DB claim is null', async () => {
+    //jwtHelper.validateRefreshToken returns null → service must throw.
+    jwtHelper.validateRefreshToken.mockReturnValue(null);
+
+    await expect(service.refreshToken('rt-anything')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    // Fail-fast: neither DB lookup nor audit must run if the claim is null,
+    // otherwise a future regression that adds an audit between the two
+    // would silently surface a log entry for an unauthenticated request.
+    expect(refreshRepo.findToken).not.toHaveBeenCalled();
+    expect(audit.authFailure).not.toHaveBeenCalled();
+    expect(refreshRepo.revokeToken).not.toHaveBeenCalled();
+    expect(refreshRepo.saveRefreshToken).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/auth/providers/refreshToken.repository.ts
+++ b/backend/src/auth/providers/refreshToken.repository.ts
@@ -1,9 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
 import { RefreshToken } from '../entities/refreshToken.entity';
 import { User } from '../../users/entities/user.entity';
 
+/**
+ * BE-04 — Refresh-token rotation & family-based revocation.
+ *
+ * A "family" is a UUID assigned to the first refresh token issued at
+ * login. Every rotation of that token inherits the same family, so
+ * the lineage of a single login session is identifiable in the DB.
+ * If a revoked token is presented again (replay attempt), the entire
+ * family is revoked — every device that authenticated through the
+ * same login is logged out.
+ */
 @Injectable()
 export class RefreshTokenRepositoryOperations {
   constructor(
@@ -11,7 +22,16 @@ export class RefreshTokenRepositoryOperations {
     private readonly repo: Repository<RefreshToken>,
   ) {}
 
-  async saveRefreshToken(user: User, token: string): Promise<RefreshToken> {
+  /**
+   * Persist a refresh token for a user. A fresh family is minted when
+   * none is supplied (e.g. on initial login). On rotation, the caller
+   * reuses the previous token's family so lineage stays intact.
+   */
+  async saveRefreshToken(
+    user: User,
+    token: string,
+    family?: string,
+  ): Promise<RefreshToken> {
     const expiresAt = this.computeExpiryFromEnv();
 
     const rt = this.repo.create({
@@ -19,20 +39,35 @@ export class RefreshTokenRepositoryOperations {
       token,
       expiresAt,
       revoked: false,
+      family: family ?? randomUUID(),
     });
 
     return this.repo.save(rt);
   }
 
-  async revokeToken(token: string): Promise<void> {
-    await this.repo.update({ token }, { revoked: true });
+  async revokeToken(
+    token: string,
+    reason: 'logout' | 'rotation' | 'replay' | 'password_reset' | 'admin' = 'logout',
+  ): Promise<void> {
+    await this.repo.update({ token }, { revoked: true, revokedReason: reason });
   }
 
+  /**
+   * Look up a refresh token regardless of revoked state.
+   * Used by the rotation flow to distinguish "valid" from "replayed".
+   */
+  async findToken(token: string): Promise<RefreshToken | null> {
+    return this.repo.findOne({ where: { token } });
+  }
+
+  /**
+   * Look up a refresh token, but only consider it usable if it is
+   * neither revoked nor expired.
+   */
   async findValidToken(token: string): Promise<RefreshToken | null> {
     const rt = await this.repo.findOne({ where: { token } });
     if (!rt) return null;
-    if (rt.revoked) return null;
-    if (rt.expiresAt && rt.expiresAt < new Date()) return null;
+    if (!rt.isUsable()) return null;
     return rt;
   }
 
@@ -48,7 +83,33 @@ export class RefreshTokenRepositoryOperations {
     return undefined;
   }
 
-  async revokeAllRefreshTokens(userId: string): Promise<void> {
-    await this.repo.update({ userId }, { revoked: true });
+  /**
+   * Revoke every refresh token belonging to a user. Used at logout,
+   * password reset, and admin-driven session termination.
+   */
+  async revokeAllRefreshTokens(
+    userId: string,
+    reason: 'logout' | 'rotation' | 'replay' | 'password_reset' | 'admin' = 'logout',
+  ): Promise<void> {
+    await this.repo.update(
+      { userId, revoked: false },
+      { revoked: true, revokedReason: reason },
+    );
+  }
+
+  /**
+   * Revoke every refresh token that shares the given family id.
+   * Triggered when a revoked token is replayed — best-effort to
+   * evict any sibling a stolen token could have rotated into.
+   */
+  async revokeFamily(
+    family: string,
+    reason: 'replay' | 'logout' | 'rotation' | 'password_reset' | 'admin' = 'replay',
+  ): Promise<void> {
+    if (!family) return;
+    await this.repo.update(
+      { family, revoked: false },
+      { revoked: true, revokedReason: reason },
+    );
   }
 }

--- a/backend/src/auth/providers/setup-totp.provider.ts
+++ b/backend/src/auth/providers/setup-totp.provider.ts
@@ -3,11 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { generateSecret, generateURI } from 'otplib';
 import * as QRCode from 'qrcode';
-import * as bcrypt from 'bcrypt';
-import * as crypto from 'crypto';
 import { User } from '../../users/entities/user.entity';
 import { Setup2faDto } from '../dto/setup-2fa.dto';
 import { verifySync } from 'otplib';
+import {
+  generateAndHashBackupCodes,
+} from './manage-totp.provider';
 
 @Injectable()
 export class SetupTotpProvider {
@@ -34,6 +35,12 @@ export class SetupTotpProvider {
     return { secret, qrCodeDataUrl };
   }
 
+  /**
+   * BE-06 — Finalise 2FA enrollment and hand the user their first
+   * batch of recovery codes. The hash policy is shared with the
+   * regeneration path via `generateAndHashBackupCodes` so the rules
+   * (count, entropy, bcrypt cost) cannot drift apart.
+   */
   async confirm2faSetup(userId: string, dto: Setup2faDto) {
     const user = await this.usersRepository.findOne({ where: { id: userId } });
     if (!user || !user.totpSecret) {
@@ -45,18 +52,12 @@ export class SetupTotpProvider {
       throw new UnauthorizedException('Invalid TOTP code');
     }
 
-    // Generate 8 plain backup codes, store hashed
-    const plainCodes = Array.from({ length: 8 }, () =>
-      crypto.randomBytes(5).toString('hex'),
-    );
-    const hashedCodes = await Promise.all(
-      plainCodes.map((c) => bcrypt.hash(c, 10)),
-    );
+    const { plain, hashed } = await generateAndHashBackupCodes();
 
     user.twoFactorEnabled = true;
-    user.totpBackupCodes = hashedCodes;
+    user.totpBackupCodes = hashed;
     await this.usersRepository.save(user);
 
-    return { backupCodes: plainCodes };
+    return { backupCodes: plain };
   }
 }

--- a/backend/src/migrations/1711900000000-AddFamilyAndRevokedReasonToRefreshToken.ts
+++ b/backend/src/migrations/1711900000000-AddFamilyAndRevokedReasonToRefreshToken.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * BE-04 — Add `family` and `revokedReason` to refresh_tokens.
+ *
+ * The rotation flow in `AuthService.refreshToken` links every refresh
+ * token minted for one login session to a common `family` UUID. The
+ * replay-detection then walks the family and revokes the entire
+ * lineage when a revoked token is presented a second time.
+ *
+ * `revokedReason` lets audit trails distinguish "logout" from
+ * "rotation" from "replay detected" without parsing free-text logs.
+ *
+ * Both columns are nullable so an in-place deploy stays green: existing
+ * rows (issued without these columns) remain valid, and any row that
+ * happens to be replayed before the deploy completes will fall back to
+ * the safe no-op path documented in `revokeFamily`.
+ */
+export class AddFamilyAndRevokedReasonToRefreshToken1711900000000
+  implements MigrationInterface
+{
+  name = 'AddFamilyAndRevokedReasonToRefreshToken1711900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "refresh_tokens"
+      ADD COLUMN IF NOT EXISTS "family" uuid
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_refresh_tokens_family"
+      ON "refresh_tokens" ("family")
+    `);
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_type
+          WHERE typname = 'refresh_tokens_revoked_reason_enum'
+        ) THEN
+          CREATE TYPE "refresh_tokens_revoked_reason_enum" AS ENUM (
+            'logout', 'rotation', 'replay', 'password_reset', 'admin'
+          );
+        END IF;
+      END$$
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "refresh_tokens"
+      ADD COLUMN IF NOT EXISTS "revoked_reason"
+      "refresh_tokens_revoked_reason_enum"
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "refresh_tokens"
+      DROP COLUMN IF EXISTS "revoked_reason"
+    `);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "refresh_tokens_revoked_reason_enum"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_refresh_tokens_family"`);
+    await queryRunner.query(`
+      ALTER TABLE "refresh_tokens"
+      DROP COLUMN IF EXISTS "family"
+    `);
+  }
+}


### PR DESCRIPTION
Closes #7, Closes #9

## Summary

This PR resolves both Stellar-Wave issues assigned to **@judithJn** in a single change set.

### BE-04 — Refresh-token rotation with replay detection
- Added `family` (uuid) and `revoked_reason` (enum) columns to `refresh_tokens` via a new TypeORM migration.
- `POST /auth/refresh-token` now **rotates** the refresh token on every successful use: the old one is revoked in the same family, a new pair is minted and persisted in DB.
- **Replay detection** — reusing a revoked refresh token now triggers family-wide revocation so a stolen sibling cannot keep the session alive, and an audit row is logged with reason `refresh_token_replay`.
- New `POST /auth/logout` endpoint revokes the supplied refresh token.
- `/auth/login` and `/auth/verify-otp` now persist refresh tokens so rotation + logout can actually invalidate them.
- `JwtHelper.validateRefreshToken` returns `{userId, family} | null` (the single caller null-checks explicitly).

### BE-06 — Backup recovery codes for two-factor authentication
- New `POST /auth/2fa/backup-codes/regenerate` endpoint, guarded by `JwtAuthGuard`. Caller must re-supply their current password so a hijacked access token cannot silently rotate backup codes.
- `SetupTotpProvider` and `ManageTotpProvider` now share a single `generateAndHashBackupCodes()` helper so the policy (count, entropy, bcrypt cost) cannot drift between setup and regeneration.
- Recovery flow documented inline in `ManageTotpProvider.regenerateBackupCodes`.

### Tests added
- `refresh-token-rotation.spec.ts` — happy rotation, replay/wipe-family, missing-DB-row, expired-token, null-JWT-claim. Each test asserts no unintended side effects past the fail-fast gate.
- `backup-codes-regeneration.spec.ts` — 8 fresh codes with hash-only storage, wrong password rejected, refuses when 2FA is disabled, missing user rejected.

## Files changed (11)
| Kind | Path |
|---|---|
| modified | `backend/src/auth/auth.controller.ts` |
| modified | `backend/src/auth/auth.service.ts` |
| modified | `backend/src/auth/entities/refreshToken.entity.ts` |
| modified | `backend/src/auth/helper/jwt-helper.ts` |
| modified | `backend/src/auth/providers/manage-totp.provider.ts` |
| modified | `backend/src/auth/providers/refreshToken.repository.ts` |
| modified | `backend/src/auth/providers/setup-totp.provider.ts` |
| added    | `backend/src/auth/dto/regenerate-backup-codes.dto.ts` |
| added    | `backend/src/auth/providers/backup-codes-regeneration.spec.ts` |
| added    | `backend/src/auth/providers/refresh-token-rotation.spec.ts` |
| added    | `backend/src/migrations/1711900000000-AddFamilyAndRevokedReasonToRefreshToken.ts` |

## Notes for reviewers / frontend

1. **`POST /auth/refresh-token` response shape changed** from `{ accessToken }` to `{ accessToken, refreshToken }`. The old refresh token is revoked on rotation — frontend **must** persist the rotated `refreshToken`, otherwise the next silent refresh will 401.
2. **`POST /auth/login` is now additive** — same fields, plus `refreshToken`. Clients that don't read it still work; clients that do need to start persisting it.
3. **`disable2fa` now best-effort revokes every active session** via a `logger.warn`-only `try`/`catch`. Silent on failure by design.
4. **Pre-deploy housekeeping**: run `cleanup.service.ts` (or equivalent purge) to drop any `refresh_tokens` rows with `family IS NULL`. Replay of those early-deploy rows short-circuits on the safe `revokeFamily(, replay)` no-op path.

## Migrations
The migration `AddFamilyAndRevokedReasonToRefreshToken1711900000000` is **forward-compatible** (`IF NOT EXISTS` guards + `DO $$ ... $$` enum guard) so an in-place deploy stays green even if it is applied out-of-order with respect to deployment of the application code. Recommended order is still: deploy migration → deploy app.