### PR TITLE
fix(manage_hub): batch item results, list_tokens pagination, reward f…

### DIFF
--- a/contracts/manage_hub/src/batch.rs
+++ b/contracts/manage_hub/src/batch.rs
@@ -3,23 +3,27 @@
 
 use crate::errors::Error;
 use crate::membership_token::MembershipTokenContract;
-use crate::types::{BatchMintParams, BatchTransferParams, BatchUpdateParams};
+use crate::types::{
+    BatchItemResult, BatchMintParams, BatchTransferParams, BatchUpdateParams,
+};
 use crate::validation::BatchValidator;
 use soroban_sdk::{symbol_short, Env, Vec};
 
 pub struct BatchModule;
+
 /// Implementation of batch operations for the MembershipTokenContract.
+///
+/// Each batch entry returns a [`BatchItemResult`]. Authorization and batch-size
+/// checks still fail the whole call; per-item failures are reported individually
+/// so callers know which index caused the problem without a full revert.
 impl BatchModule {
     /// Mints multiple tokens in a single transaction.
     /// Requires admin authorization for each mint if issue_token requires it.
-    ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    /// * `params_vec` - Vector of minting parameters for each token
-    pub fn batch_mint(env: Env, params_vec: Vec<BatchMintParams>) -> Result<(), Error> {
+    pub fn batch_mint(env: Env, params_vec: Vec<BatchMintParams>) -> Result<Vec<BatchItemResult>, Error> {
         BatchValidator::validate_batch_size(params_vec.len())?;
 
-        MembershipTokenContract::batch_issue_tokens(env.clone(), params_vec.clone())?;
+        let results =
+            MembershipTokenContract::batch_issue_tokens(env.clone(), params_vec.clone())?;
 
         // Emit batch event for tracking and monitoring
         env.events().publish(
@@ -27,46 +31,44 @@ impl BatchModule {
             (params_vec.len(), env.ledger().timestamp()),
         );
 
-        Ok(())
+        Ok(results)
     }
 
     /// Transfers multiple tokens to different recipients in a single transaction.
     /// Requires authorization from each current token owner.
-    ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    /// * `params_vec` - Vector of transfer parameters for each token
-    pub fn batch_transfer(env: Env, params_vec: Vec<BatchTransferParams>) -> Result<(), Error> {
+    pub fn batch_transfer(
+        env: Env,
+        params_vec: Vec<BatchTransferParams>,
+    ) -> Result<Vec<BatchItemResult>, Error> {
         BatchValidator::validate_batch_size(params_vec.len())?;
 
-        MembershipTokenContract::batch_transfer_tokens(env.clone(), params_vec.clone())?;
+        let results =
+            MembershipTokenContract::batch_transfer_tokens(env.clone(), params_vec.clone())?;
 
-        // Emit batch event for tracking and monitoring
         env.events().publish(
             (symbol_short!("bat_xfr"),),
             (params_vec.len(), env.ledger().timestamp()),
         );
 
-        Ok(())
+        Ok(results)
     }
 
     /// Updates metadata for multiple tokens in a single transaction.
     /// Requires authorization from each token owner (or admin).
-    ///
-    /// # Arguments
-    /// * `env` - The contract environment
-    /// * `params_vec` - Vector of update parameters for each token
-    pub fn batch_update(env: Env, params_vec: Vec<BatchUpdateParams>) -> Result<(), Error> {
+    pub fn batch_update(
+        env: Env,
+        params_vec: Vec<BatchUpdateParams>,
+    ) -> Result<Vec<BatchItemResult>, Error> {
         BatchValidator::validate_batch_size(params_vec.len())?;
 
-        MembershipTokenContract::batch_set_token_metadata(env.clone(), params_vec.clone())?;
+        let results =
+            MembershipTokenContract::batch_set_token_metadata(env.clone(), params_vec.clone())?;
 
-        // Emit batch event for tracking and monitoring
         env.events().publish(
             (symbol_short!("bat_upd"),),
             (params_vec.len(), env.ledger().timestamp()),
         );
 
-        Ok(())
+        Ok(results)
     }
 }

--- a/contracts/manage_hub/src/edge_case_tests.rs
+++ b/contracts/manage_hub/src/edge_case_tests.rs
@@ -9,7 +9,7 @@
 use super::*;
 use crate::membership_token::{DataKey as MembershipDataKey, MembershipTokenContract};
 use crate::types::MembershipStatus;
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, BytesN as _};
 use soroban_sdk::{map, Address, BytesN, Env, String};
 
 // ---------------------------------------------------------------------------
@@ -373,4 +373,135 @@ fn test_hello_with_empty_string() {
     let result = client.hello(&String::from_str(&env, ""));
     assert_eq!(result.len(), 1);
     assert_eq!(result.get(0).unwrap(), String::from_str(&env, ""));
+}
+
+// ---------------------------------------------------------------------------
+// #280 — Batch operations per-item error reporting
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_mint_reports_per_item_success_and_failure() {
+    let (env, admin, contract_id) = setup_contract();
+    let client = ContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let expiry = env.ledger().timestamp() + 86_400;
+    let id_ok = BytesN::<32>::random(&env);
+    let id_dup = id_ok.clone();
+
+    // Pre-issue so the second batch entry collides.
+    client.issue_token(&id_ok, &user, &expiry);
+
+    let mut batch = soroban_sdk::Vec::new(&env);
+    let id_new = BytesN::<32>::random(&env);
+    batch.push_back(crate::types::BatchMintParams {
+        id: id_new.clone(),
+        user: user.clone(),
+        expiry_date: expiry,
+    });
+    batch.push_back(crate::types::BatchMintParams {
+        id: id_dup,
+        user: user.clone(),
+        expiry_date: expiry,
+    });
+
+    let results = client.batch_mint(&batch);
+    assert_eq!(results.len(), 2);
+    let first = results.get(0).unwrap();
+    assert_eq!(first.index, 0);
+    assert_eq!(first.token_id, id_new);
+    assert!(first.success);
+    assert_eq!(first.error_code, 0);
+
+    let second = results.get(1).unwrap();
+    assert_eq!(second.index, 1);
+    assert!(!second.success);
+    assert_eq!(second.error_code, u32::from(crate::errors::Error::TokenAlreadyIssued));
+}
+
+#[test]
+fn test_batch_transfer_reports_missing_token() {
+    let (env, _admin, contract_id) = setup_contract();
+    let client = ContractClient::new(&env, &contract_id);
+
+    let missing = BytesN::<32>::random(&env);
+    let recipient = Address::generate(&env);
+    let mut batch = soroban_sdk::Vec::new(&env);
+    batch.push_back(crate::types::BatchTransferParams {
+        id: missing.clone(),
+        new_user: recipient,
+    });
+
+    let results = client.batch_transfer(&batch);
+    assert_eq!(results.len(), 1);
+    let item = results.get(0).unwrap();
+    assert!(!item.success);
+    assert_eq!(item.token_id, missing);
+    assert_eq!(item.error_code, u32::from(crate::errors::Error::TokenNotFound));
+}
+
+// ---------------------------------------------------------------------------
+// #282 — Paginated list_tokens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_list_tokens_paginated_success_and_invalid_page() {
+    let (env, admin, contract_id) = setup_contract();
+    let client = ContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let expiry = env.ledger().timestamp() + 86_400;
+    let key = String::from_str(&env, "tier");
+    let value = common_types::MetadataValue::Text(String::from_str(&env, "gold"));
+
+    // Issue three tokens and tag them with the same attribute.
+    let mut ids = soroban_sdk::Vec::new(&env);
+    for _ in 0..3 {
+        let tid = BytesN::<32>::random(&env);
+        client.issue_token(&tid, &user, &expiry);
+        let mut attrs = soroban_sdk::Map::new(&env);
+        attrs.set(key.clone(), value.clone());
+        client.set_token_metadata(
+            &tid,
+            &String::from_str(&env, "gold member"),
+            &attrs,
+        );
+        ids.push_back(tid);
+    }
+
+    // Full query should see all three.
+    let all = client.query_tokens_by_attribute(&key, &value);
+    assert_eq!(all.len(), 3);
+
+    // Page size 2, first page.
+    let page0 = client.list_tokens(
+        &key,
+        &value,
+        &common_types::PageParams { offset: 0, limit: 2 },
+    );
+    assert_eq!(page0.len(), 2);
+
+    // Second page.
+    let page1 = client.list_tokens(
+        &key,
+        &value,
+        &common_types::PageParams { offset: 2, limit: 2 },
+    );
+    assert_eq!(page1.len(), 1);
+
+    // Invalid limit (> MAX_PAGE_SIZE) returns empty.
+    let invalid = client.list_tokens(
+        &key,
+        &value,
+        &common_types::PageParams { offset: 0, limit: 10_000 },
+    );
+    assert_eq!(invalid.len(), 0);
+
+    // Offset past end returns empty.
+    let past = client.list_tokens(
+        &key,
+        &value,
+        &common_types::PageParams { offset: 99, limit: 10 },
+    );
+    assert_eq!(past.len(), 0);
 }

--- a/contracts/manage_hub/src/lib.rs
+++ b/contracts/manage_hub/src/lib.rs
@@ -101,8 +101,8 @@ use membership_token::{MembershipToken, MembershipTokenContract};
 use staking::StakingModule;
 use subscription::SubscriptionContract;
 use types::{
-    AttendanceAction, AttendanceSummary, BatchMintParams, BatchTransferParams, BatchUpdateParams,
-    BatchUpgradeResult, BillingCycle, CreatePromotionParams, CreateTierParams,
+    AttendanceAction, AttendanceSummary, BatchItemResult, BatchMintParams, BatchTransferParams,
+    BatchUpdateParams, BatchUpgradeResult, BillingCycle, CreatePromotionParams, CreateTierParams,
     DividendDistribution, EmergencyPauseState, FractionHolder, MembershipStatus, PauseConfig,
     PauseHistoryEntry, PauseStats, StakeInfo, StakingConfig, StakingTier, Subscription,
     SubscriptionTier, TierAnalytics, TierFeature, TierPromotion, TokenAllowance, UpdateTierParams,
@@ -120,17 +120,29 @@ impl Contract {
     }
 
     /// Mints multiple tokens in a single transaction.
-    pub fn batch_mint(env: Env, params: Vec<BatchMintParams>) -> Result<(), Error> {
+    /// Returns per-item outcomes so callers can identify which index failed.
+    pub fn batch_mint(
+        env: Env,
+        params: Vec<BatchMintParams>,
+    ) -> Result<Vec<BatchItemResult>, Error> {
         BatchModule::batch_mint(env, params)
     }
 
     /// Transfers multiple tokens in a single transaction.
-    pub fn batch_transfer(env: Env, params: Vec<BatchTransferParams>) -> Result<(), Error> {
+    /// Returns per-item outcomes so callers can identify which index failed.
+    pub fn batch_transfer(
+        env: Env,
+        params: Vec<BatchTransferParams>,
+    ) -> Result<Vec<BatchItemResult>, Error> {
         BatchModule::batch_transfer(env, params)
     }
 
     /// Updates metadata for multiple tokens in a single transaction.
-    pub fn batch_update(env: Env, params: Vec<BatchUpdateParams>) -> Result<(), Error> {
+    /// Returns per-item outcomes so callers can identify which index failed.
+    pub fn batch_update(
+        env: Env,
+        params: Vec<BatchUpdateParams>,
+    ) -> Result<Vec<BatchItemResult>, Error> {
         BatchModule::batch_update(env, params)
     }
 
@@ -704,6 +716,22 @@ impl Contract {
         attribute_value: MetadataValue,
     ) -> Vec<BytesN<32>> {
         MembershipTokenContract::query_tokens_by_attribute(env, attribute_key, attribute_value)
+    }
+
+    /// Paginated listing of membership tokens matching a metadata attribute.
+    /// Analogous to `get_staking_tiers_paginated` for large membership bases.
+    pub fn list_tokens(
+        env: Env,
+        attribute_key: String,
+        attribute_value: MetadataValue,
+        page: PageParams,
+    ) -> Vec<BytesN<32>> {
+        MembershipTokenContract::list_tokens_by_attribute(
+            env,
+            attribute_key,
+            attribute_value,
+            page,
+        )
     }
 
     // ============================================================================

--- a/contracts/manage_hub/src/membership_token.rs
+++ b/contracts/manage_hub/src/membership_token.rs
@@ -156,7 +156,7 @@ impl MembershipTokenContract {
     pub fn batch_issue_tokens(
         env: Env,
         params: Vec<crate::types::BatchMintParams>,
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<crate::types::BatchItemResult>, Error> {
         PauseGuard::require_not_paused(&env)?;
 
         let admin: Address = env
@@ -166,11 +166,24 @@ impl MembershipTokenContract {
             .ok_or(Error::AdminNotSet)?;
         admin.require_auth();
 
+        let mut results: Vec<crate::types::BatchItemResult> = Vec::new(&env);
+        let mut index: u32 = 0;
         for p in params.iter() {
-            Self::internal_issue_token(&env, &admin, p.id, p.user, p.expiry_date)?;
+            let outcome = Self::internal_issue_token(&env, &admin, p.id.clone(), p.user, p.expiry_date);
+            let (success, error_code) = match outcome {
+                Ok(()) => (true, 0u32),
+                Err(e) => (false, u32::from(e)),
+            };
+            results.push_back(crate::types::BatchItemResult {
+                index,
+                token_id: p.id.clone(),
+                success,
+                error_code,
+            });
+            index = index.saturating_add(1);
         }
 
-        Ok(())
+        Ok(results)
     }
 
     pub fn transfer_token(env: Env, id: BytesN<32>, new_user: Address) -> Result<(), Error> {
@@ -253,14 +266,27 @@ impl MembershipTokenContract {
     pub fn batch_transfer_tokens(
         env: Env,
         params: Vec<crate::types::BatchTransferParams>,
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<crate::types::BatchItemResult>, Error> {
         PauseGuard::require_not_paused(&env)?;
 
+        let mut results: Vec<crate::types::BatchItemResult> = Vec::new(&env);
+        let mut index: u32 = 0;
         for p in params.iter() {
-            Self::internal_transfer_token(&env, p.id, p.new_user)?;
+            let outcome = Self::internal_transfer_token(&env, p.id.clone(), p.new_user);
+            let (success, error_code) = match outcome {
+                Ok(()) => (true, 0u32),
+                Err(e) => (false, u32::from(e)),
+            };
+            results.push_back(crate::types::BatchItemResult {
+                index,
+                token_id: p.id.clone(),
+                success,
+                error_code,
+            });
+            index = index.saturating_add(1);
         }
 
-        Ok(())
+        Ok(results)
     }
 
     pub fn approve(
@@ -636,18 +662,37 @@ impl MembershipTokenContract {
     pub fn batch_set_token_metadata(
         env: Env,
         params: Vec<crate::types::BatchUpdateParams>,
-    ) -> Result<(), Error> {
+    ) -> Result<Vec<crate::types::BatchItemResult>, Error> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::AdminNotSet)?;
 
+        let mut results: Vec<crate::types::BatchItemResult> = Vec::new(&env);
+        let mut index: u32 = 0;
         for p in params.iter() {
-            Self::internal_set_token_metadata(&env, &admin, p.id, p.description, p.attributes)?;
+            let outcome = Self::internal_set_token_metadata(
+                &env,
+                &admin,
+                p.id.clone(),
+                p.description,
+                p.attributes,
+            );
+            let (success, error_code) = match outcome {
+                Ok(()) => (true, 0u32),
+                Err(e) => (false, u32::from(e)),
+            };
+            results.push_back(crate::types::BatchItemResult {
+                index,
+                token_id: p.id.clone(),
+                success,
+                error_code,
+            });
+            index = index.saturating_add(1);
         }
 
-        Ok(())
+        Ok(results)
     }
 
     /// Gets metadata for a token.
@@ -894,6 +939,39 @@ impl MembershipTokenContract {
             .persistent()
             .get(&index_key)
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Paginated membership-token listing by metadata attribute.
+    ///
+    /// Analogous to `get_staking_tiers_paginated` / workspace listing helpers:
+    /// returns at most `page.limit` token ids starting at `page.offset` from the
+    /// attribute index, so large membership bases do not hit instruction limits.
+    ///
+    /// Invalid page params (limit == 0 or limit > MAX_PAGE_SIZE) yield an empty
+    /// vector rather than panicking, matching the staking pagination contract.
+    pub fn list_tokens_by_attribute(
+        env: Env,
+        attribute_key: String,
+        attribute_value: MetadataValue,
+        page: common_types::PageParams,
+    ) -> Vec<BytesN<32>> {
+        if common_types::validate_page_params(page.offset, page.limit).is_err() {
+            return Vec::new(&env);
+        }
+
+        let all: Vec<BytesN<32>> = Self::query_tokens_by_attribute(
+            env.clone(),
+            attribute_key,
+            attribute_value,
+        );
+        let total = all.len();
+        if page.offset >= total || page.limit == 0 {
+            return Vec::new(&env);
+        }
+        let remaining = total - page.offset;
+        let take = remaining.min(page.limit);
+        let end = page.offset + take;
+        all.slice(page.offset..end)
     }
 
     // ============================================================================

--- a/contracts/manage_hub/src/types.rs
+++ b/contracts/manage_hub/src/types.rs
@@ -30,6 +30,22 @@ pub struct BatchUpdateParams {
     pub attributes: soroban_sdk::Map<String, MetadataValue>,
 }
 
+/// Per-item outcome for batch mint / transfer / update operations.
+/// Mirrors [`BatchUpgradeResult`] so callers can see which index failed
+/// without the whole transaction reverting on the first error.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BatchItemResult {
+    /// Zero-based index of the item in the input vector.
+    pub index: u32,
+    /// Token id associated with this item (when available).
+    pub token_id: BytesN<32>,
+    /// Whether the operation succeeded for this item.
+    pub success: bool,
+    /// Error code (as u32) when `success` is false; 0 on success.
+    pub error_code: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub enum AttendanceAction {

--- a/contracts/scripts/deploy_testnet.sh
+++ b/contracts/scripts/deploy_testnet.sh
@@ -33,6 +33,7 @@ ENV_FILE="$SCRIPT_DIR/../.env.deployed"
 NETWORK="testnet"
 SOROBAN_RPC_URL="${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}"
 ADMIN_ADDRESS="${ADMIN_ADDRESS:-}"
+FORCE_REDEPLOY=0
 CONTRACTS=(
     "access_control"
     "manage_hub"
@@ -61,8 +62,12 @@ while [[ $# -gt 0 ]]; do
             SOROBAN_RPC_URL="$2"
             shift 2
             ;;
+        --force)
+            FORCE_REDEPLOY=1
+            shift
+            ;;
         --help|-h)
-            echo "Usage: $0 [--admin <address>] [--network <network>] [--rpc-url <url>]"
+            echo "Usage: $0 [--admin <address>] [--network <network>] [--rpc-url <url>] [--force]"
             echo ""
             echo "Deploy all Oraculum contracts to Stellar testnet."
             echo ""
@@ -169,10 +174,30 @@ for contract in "${CONTRACTS[@]}"; do
         continue
     fi
 
-    # Check if already deployed (idempotent)
-    if [[ -n "${DEPLOYED_ADDRESSES[$env_key]:-}" ]]; then
-        echo "  SKIP: $contract already deployed at ${DEPLOYED_ADDRESSES[$env_key]}"
-        continue
+    # Idempotency: skip when we already recorded an address unless --force is set.
+    # Optionally verify the account still hosts WASM on-chain to avoid stale .env entries.
+    if [[ -n "${DEPLOYED_ADDRESSES[$env_key]:-}" && "$FORCE_REDEPLOY" -eq 0 ]]; then
+        existing="${DEPLOYED_ADDRESSES[$env_key]}"
+        on_chain_ok=0
+        if command -v stellar >/dev/null 2>&1; then
+            if stellar contract info interface                 --contract-id "$existing"                 --network "$NETWORK"                 --rpc-url "$SOROBAN_RPC_URL"                 >/dev/null 2>&1; then
+                on_chain_ok=1
+            fi
+        else
+            # stellar CLI unavailable — trust the recorded address
+            on_chain_ok=1
+        fi
+
+        if [[ "$on_chain_ok" -eq 1 ]]; then
+            echo "  SKIP: $contract already deployed at $existing (idempotent)"
+            continue
+        else
+            echo "  WARN: recorded address $existing for $contract is not live; redeploying"
+        fi
+    fi
+
+    if [[ -n "${DEPLOYED_ADDRESSES[$env_key]:-}" && "$FORCE_REDEPLOY" -eq 1 ]]; then
+        echo "  FORCE: redeploying $contract (was ${DEPLOYED_ADDRESSES[$env_key]})"
     fi
 
     echo "  Deploying $contract..."

--- a/contracts/tests/fuzz_arithmetic_tests.rs
+++ b/contracts/tests/fuzz_arithmetic_tests.rs
@@ -1,12 +1,44 @@
 #[cfg(test)]
 mod fuzz_arithmetic_tests {
+    /// Mirror of manage_hub rewards formula constants / shape so overflow
+    /// scenarios stay covered without pulling the full contract into this crate.
+    const YEAR_SECS: i128 = 31_536_000;
+    const BPS_DENOM: i128 = 10_000;
+
+    /// gross = amount * base_rate_bps * elapsed * multiplier_bps
+    ///         / (10_000 * YEAR_SECS * 10_000)
+    fn calculate_pending_rewards_checked(
+        amount: i128,
+        base_rate_bps: i128,
+        elapsed: i128,
+        multiplier_bps: i128,
+        claimed_rewards: i128,
+    ) -> Result<i128, ()> {
+        let gross = amount
+            .checked_mul(base_rate_bps)
+            .ok_or(())?
+            .checked_mul(elapsed)
+            .ok_or(())?
+            .checked_mul(multiplier_bps)
+            .ok_or(())?
+            .checked_div(BPS_DENOM.checked_mul(YEAR_SECS).ok_or(())?)
+            .ok_or(())?
+            .checked_div(BPS_DENOM)
+            .ok_or(())?;
+
+        Ok(gross.checked_sub(claimed_rewards).unwrap_or(0).max(0))
+    }
+
     #[test]
     fn test_safe_add_overflow() {
         let a: u128 = u128::MAX / 2;
         let b: u128 = u128::MAX / 2;
-        assert!(a.checked_add(b).is_some(), "Safe addition should not overflow");
+        assert!(
+            a.checked_add(b).is_some(),
+            "Safe addition should not overflow"
+        );
     }
-// return Err("Zero-address admin initialization not allowed");
+
     #[test]
     fn test_safe_mul_pricing() {
         let qty: u64 = 1_000_000;
@@ -19,7 +51,9 @@ mod fuzz_arithmetic_tests {
     fn test_fee_calculation_precision() {
         let amount: u128 = 1_000_000_000;
         let fee_percent = 5u128;
-        let fee = amount.checked_mul(fee_percent).and_then(|f| f.checked_div(100));
+        let fee = amount
+            .checked_mul(fee_percent)
+            .and_then(|f| f.checked_div(100));
         assert!(fee.is_some(), "Fee calc should handle safely");
     }
 
@@ -30,5 +64,80 @@ mod fuzz_arithmetic_tests {
         let per_share = total.checked_div(shares);
         assert!(per_share.is_some(), "Share division should be safe");
         assert_eq!(per_share.unwrap(), 10_000_000);
+    }
+
+    // -----------------------------------------------------------------------
+    // #283 — Staking reward overflow scenarios (rewards.rs)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reward_calc_normal_path() {
+        // 1_000 principal, 500 bps (5%), 1 year, 1x multiplier
+        let pending = calculate_pending_rewards_checked(1_000, 500, YEAR_SECS, 10_000, 0)
+            .expect("normal reward path must not overflow");
+        // gross = 1000 * 500 * YEAR * 10000 / (10000 * YEAR * 10000) = 50
+        assert_eq!(pending, 50);
+    }
+
+    #[test]
+    fn test_reward_calc_amount_times_rate_overflow() {
+        // amount * base_rate_bps overflows i128
+        let amount = i128::MAX / 2;
+        let rate = 10_000i128;
+        let result = calculate_pending_rewards_checked(amount, rate, 1, 10_000, 0);
+        assert!(result.is_err(), "amount * rate_bps must fail on overflow");
+    }
+
+    #[test]
+    fn test_reward_calc_elapsed_overflow() {
+        // After rate multiply, * elapsed overflows
+        let amount = i128::MAX / 20_000;
+        let rate = 10_000i128;
+        let elapsed = i128::MAX; // forces second multiply overflow
+        let result = calculate_pending_rewards_checked(amount, rate, elapsed, 10_000, 0);
+        assert!(
+            result.is_err(),
+            "principal*rate*elapsed must fail on overflow"
+        );
+    }
+
+    #[test]
+    fn test_reward_calc_multiplier_overflow() {
+        let amount = i128::MAX / 20_000;
+        let rate = 5_000i128;
+        let elapsed = 10_000i128;
+        let multiplier = i128::MAX; // forces multiplier stage overflow
+        let result = calculate_pending_rewards_checked(amount, rate, elapsed, multiplier, 0);
+        assert!(
+            result.is_err(),
+            "including reward_multiplier_bps must fail on overflow"
+        );
+    }
+
+    #[test]
+    fn test_reward_calc_large_but_safe_values() {
+        // Large but carefully bounded inputs that still fit i128 through the pipeline.
+        let amount = 1_000_000_000_000i128; // 1e12
+        let rate = 1_000i128; // 10%
+        let elapsed = YEAR_SECS;
+        let multiplier = 10_000i128;
+        let pending =
+            calculate_pending_rewards_checked(amount, rate, elapsed, multiplier, 0).expect("safe");
+        // gross = amount * 1000 / 10000 = amount / 10
+        assert_eq!(pending, amount / 10);
+    }
+
+    #[test]
+    fn test_reward_calc_zero_elapsed_is_zero() {
+        let pending =
+            calculate_pending_rewards_checked(1_000_000, 500, 0, 10_000, 0).expect("zero elapsed");
+        assert_eq!(pending, 0);
+    }
+
+    #[test]
+    fn test_reward_calc_claimed_subtracted() {
+        let pending =
+            calculate_pending_rewards_checked(1_000, 500, YEAR_SECS, 10_000, 20).expect("claimed");
+        assert_eq!(pending, 30);
     }
 }


### PR DESCRIPTION
## Summary
Addresses #280, #282, #283, and #278 for `manage_hub` batch reporting, membership listing pagination, reward overflow coverage, and testnet deploy idempotency.

## Changes

closes  #280  — Batch per-item error reporting
- Added `BatchItemResult { index, token_id, success, error_code }` (mirrors `BatchUpgradeResult`)
- `batch_mint`, `batch_transfer`, and `batch_update` now return `Result<Vec<BatchItemResult>, Error>`
- Auth / pause / batch-size failures still abort the call; per-item failures are recorded instead of reverting the whole batch
- Underlying `batch_issue_tokens` / `batch_transfer_tokens` / `batch_set_token_metadata` updated accordingly
- Regression tests: mixed success/failure mint, missing-token transfer

closes  #282  — Paginated `list_tokens`
- Added `list_tokens_by_attribute` + contract entrypoint `list_tokens(attribute_key, attribute_value, page: PageParams)`
- Same pagination contract as `get_staking_tiers_paginated` (`validate_page_params`, empty vec on invalid/out-of-range pages)
- Slices the metadata attribute index so large membership sets stay under instruction limits
- Regression tests: multi-page success, invalid limit, offset past end

closes  #283  — Staking reward overflow fuzz coverage
- Extended `contracts/tests/fuzz_arithmetic_tests.rs` with a checked mirror of `rewards.rs::calculate_pending_rewards`
- Cases: normal path, `amount * rate_bps` overflow, elapsed overflow, multiplier overflow, large-but-safe values, zero elapsed, claimed subtraction

 closes #278  — Deploy script idempotency
- Skip redeploy when `.env.deployed` already has an address
- Optional on-chain live check via `stellar contract info interface`
- Stale addresses trigger redeploy; `--force` forces redeploy

## Files
- `contracts/manage_hub/src/types.rs`
- `contracts/manage_hub/src/batch.rs`
- `contracts/manage_hub/src/membership_token.rs`
- `contracts/manage_hub/src/lib.rs`
- `contracts/manage_hub/src/edge_case_tests.rs`
- `contracts/tests/fuzz_arithmetic_tests.rs`
- `contracts/scripts/deploy_testnet.sh`

## Test plan
- [ ] `cargo test -p manage_hub test_batch_mint_reports_per_item_success_and_failure`
- [ ] `cargo test -p manage_hub test_batch_transfer_reports_missing_token`
- [ ] `cargo test -p manage_hub test_list_tokens_paginated_success_and_invalid_page`
- [ ] Fuzz/arithmetic tests for reward overflow cases pass
- [ ] Re-running `deploy_testnet.sh` skips already-deployed contracts; `--force` redeploys