### PR TITLE
fix: contract safety improvements — rescue_tokens, lock_duration cap, booking conflict test, supply test (#272-#275)

### DIFF
--- a/contracts/manage_hub/src/staking.rs
+++ b/contracts/manage_hub/src/staking.rs
@@ -61,6 +61,13 @@ impl StakingModule {
             return Err(Error::InvalidPaymentAmount);
         }
 
+        // ADDED BY FIX #274: Cap lock_duration to prevent permanent fund locking.
+        // 2 years in ledgers: ~63,072,000 seconds / 5s per ledger ≈ 12,614,400 ledgers
+        const MAX_LOCK_DURATION_LEDGERS: u64 = 12_614_400;
+        if config.lock_duration > MAX_LOCK_DURATION_LEDGERS {
+            return Err(Error::InvalidPaymentAmount);
+        }
+
         env.storage()
             .instance()
             .set(&StakingDataKey::Config, &config);

--- a/contracts/payment_escrow/src/lib.rs
+++ b/contracts/payment_escrow/src/lib.rs
@@ -606,3 +606,44 @@ impl PaymentEscrowContract {
     }
 }
 }
+
+// ── ADDED BY FIX #275: Token rescue for admin ──────────────────────────────
+
+/// Rescue tokens sent directly to the contract outside of the escrow flow.
+///
+/// Admin-only. Transfers the specified amount of the payment token from the
+/// contract to the recipient. This prevents tokens from being permanently
+/// locked if a user accidentally sends them to the contract address.
+///
+/// # Arguments
+/// * `caller` - Must be the admin
+/// * `recipient` - Address to receive the rescued tokens
+/// * `amount` - Amount to rescue (must be <= contract's token balance)
+pub fn rescue_tokens(
+    env: Env,
+    caller: Address,
+    recipient: Address,
+    amount: i128,
+) -> Result<(), Error> {
+    Self::require_admin(&env, &caller)?;
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let payment_token = Self::get_payment_token(&env)?;
+    let token_client = token::Client::new(&env, &payment_token);
+
+    let contract_balance = token_client.balance(&env.current_contract_address());
+    if amount > contract_balance {
+        return Err(Error::InsufficientBalance);
+    }
+
+    token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+
+    env.events().publish(
+        (symbol_short!("rescue"),),
+        (recipient, amount, env.ledger().timestamp()),
+    );
+    Ok(())
+}

--- a/contracts/resource_credits/src/test.rs
+++ b/contracts/resource_credits/src/test.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use super::{ResourceCreditsContract, ResourceCreditsContractClient};
+
+fn setup() -> (Env, Address, Address, ResourceCreditsContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, ResourceCreditsContract);
+    let client = ResourceCreditsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+    (env, admin, token, client)
+}
+
+// ── FIX #272: spend_credits → total_supply decrement test ───────────────────
+
+#[test]
+fn test_spend_credits_decrements_total_supply() {
+    let (env, admin, _token, client) = setup();
+    let member = Address::generate(&env);
+
+    // Mint 1000 credits
+    client.mint_credits(&admin, &member, &1_000u128);
+    assert_eq!(client.total_supply(), 1_000u128);
+    assert_eq!(client.balance(&member), 1_000u128);
+
+    // Spend 400 credits
+    client.spend_credits(&member, &400u128);
+
+    // Total supply should decrease by 400
+    assert_eq!(client.total_supply(), 600u128);
+    assert_eq!(client.balance(&member), 600u128);
+}
+
+#[test]
+fn test_spend_all_credits() {
+    let (env, admin, _token, client) = setup();
+    let member = Address::generate(&env);
+
+    client.mint_credits(&admin, &member, &500u128);
+    assert_eq!(client.total_supply(), 500u128);
+
+    client.spend_credits(&member, &500u128);
+    assert_eq!(client.total_supply(), 0u128);
+    assert_eq!(client.balance(&member), 0u128);
+}
+
+#[test]
+fn test_spend_insufficient_balance() {
+    let (env, admin, _token, client) = setup();
+    let member = Address::generate(&env);
+
+    client.mint_credits(&admin, &member, &100u128);
+    assert_eq!(client.total_supply(), 100u128);
+
+    let result = client.try_spend_credits(&member, &200u128);
+    assert_eq!(result, Err(Ok(super::Error::InsufficientBalance)));
+    // Supply should remain unchanged
+    assert_eq!(client.total_supply(), 100u128);
+}
+
+#[test]
+fn test_spend_zero_amount_rejected() {
+    let (env, admin, _token, client) = setup();
+    let member = Address::generate(&env);
+
+    client.mint_credits(&admin, &member, &100u128);
+
+    let result = client.try_spend_credits(&member, &0u128);
+    assert_eq!(result, Err(Ok(super::Error::InvalidAmount)));
+    assert_eq!(client.total_supply(), 100u128);
+}
+
+#[test]
+fn test_multiple_mints_and_spends() {
+    let (env, admin, _token, client) = setup();
+    let member = Address::generate(&env);
+
+    // Mint in two batches
+    client.mint_credits(&admin, &member, &300u128);
+    client.mint_credits(&admin, &member, &200u128);
+    assert_eq!(client.total_supply(), 500u128);
+
+    // Spend partially
+    client.spend_credits(&member, &150u128);
+    assert_eq!(client.total_supply(), 350u128);
+
+    // Spend again
+    client.spend_credits(&member, &100u128);
+    assert_eq!(client.total_supply(), 250u128);
+    assert_eq!(client.balance(&member), 250u128);
+}

--- a/contracts/workspace_booking/src/test.rs
+++ b/contracts/workspace_booking/src/test.rs
@@ -729,3 +729,52 @@ fn test_hourly_rate_update_applies_to_future_bookings() {
     let booking = client.get_booking(&String::from_str(&env, "bk-001"));
     assert_eq!(booking.amount_paid, 2_000u128); // new rate applied
 }
+
+// ── FIX #273: Concurrent booking conflict test ──────────────────────────────
+
+#[test]
+fn test_concurrent_booking_conflict_same_slot() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = setup_contract(&env);
+    let client = WorkspaceBookingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let token_address = setup_token(&env, &admin, &member1, 100_000i128);
+
+    client.initialize(&admin, &token_address);
+    client.register_workspace(
+        &admin,
+        &String::from_str(&env, "ws-001"),
+        &String::from_str(&env, "Meeting Room"),
+        &WorkspaceType::MeetingRoom,
+        &1u32,
+        &1_000u128,
+    );
+
+    let now = env.ledger().timestamp();
+    let start = now + 60;
+    let end = start + 3_600;
+
+    // First booking succeeds
+    client.book_workspace(
+        &member1,
+        &String::from_str(&env, "bk-001"),
+        &String::from_str(&env, "ws-001"),
+        &start,
+        &end,
+    );
+
+    // Second booking for the same slot must fail with BookingConflict
+    let result = client.try_book_workspace(
+        &member2,
+        &String::from_str(&env, "bk-002"),
+        &String::from_str(&env, "ws-001"),
+        &start,
+        &end,
+    );
+    assert_eq!(result, Err(Ok(Error::BookingConflict)));
+}


### PR DESCRIPTION
## Summary

Addresses four contract safety issues across payment_escrow, manage_hub staking, workspace_booking, and resource_credits.

## Changes

### #275 — rescue_tokens admin function
- New `rescue_tokens` function in payment_escrow for recovering tokens sent directly to the contract
- Admin-only with auth check, balance validation, and event emission
- Prevents permanent token lock from accidental transfers

### #274 — Cap lock_duration in staking_config
- Added max cap of 12,614,400 ledgers (~2 years) in `set_staking_config`
- Prevents admin from setting infinite lock periods that trap user funds
- Returns `InvalidPaymentAmount` error if exceeded

### #273 — Concurrent booking conflict test
- New test `test_concurrent_booking_conflict_same_slot` for workspace_booking
- Verifies second booking for same slot returns `BookingConflict` error

### #272 — spend_credits → total_supply decrement test
- New test file `contracts/resource_credits/src/test.rs`
- Tests: mint→spend→assert supply, spend all, insufficient balance, zero amount

Closes #272, #273, #274, #275