### PR TITLE
fix(manage-hub): resolve staking and admin safety issues

### DIFF
--- a/contracts/manage_hub/src/errors.rs
+++ b/contracts/manage_hub/src/errors.rs
@@ -61,6 +61,7 @@ pub enum Error {
     StakingTierAlreadyDeactivated = 56,
     StakingTierNotFound = 57,
     InvalidPaginationParams = 58,
+    TierMismatch = 59,
 }
 
 impl From<Error> for u32 {
@@ -131,6 +132,7 @@ impl TryFrom<u32> for Error {
             56 => Ok(Error::StakingTierAlreadyDeactivated),
             57 => Ok(Error::StakingTierNotFound),
             58 => Ok(Error::InvalidPaginationParams),
+            59 => Ok(Error::TierMismatch),
             _ => Err(v),
         }
     }
@@ -146,24 +148,4 @@ impl IntoVal<soroban_sdk::Env, soroban_sdk::Error> for Error {
     fn into_val(&self, _env: &soroban_sdk::Env) -> soroban_sdk::Error {
         soroban_sdk::Error::from_contract_error(u32::from(*self))
     }
-    // -----------------------------------------------------------------
-    // Tier / Staking Tier active state & listing gas-optimisation errors
-    // (added for CT-15, CT-16, CT-17, CT-18)
-    // -----------------------------------------------------------------
-    /// Attempted to reactivate a tier that is already active.
-    TierAlreadyActive = 51,
-    /// Attempted to deactivate a tier that is already deactivated.
-    TierAlreadyDeactivated = 52,
-    /// Attempted to reactivate a staking tier that is already active.
-    StakingTierAlreadyActive = 53,
-    /// Attempted to deactivate a staking tier that is already deactivated.
-    StakingTierAlreadyDeactivated = 54,
-    /// Staking tier with the given ID does not exist (mirrors
-    /// `TierNotFound` for the staking-tier namespace).
-    StakingTierNotFound = 55,
-    /// Pagination parameters failed validation (e.g. limit = 0,
-    /// limit > MAX_PAGE_SIZE).
-    InvalidPaginationParams = 56,
-    /// Subscription has been marked as invalid.
-    SubscriptionInvalid = 57,
 }

--- a/contracts/manage_hub/src/lib.rs
+++ b/contracts/manage_hub/src/lib.rs
@@ -83,9 +83,6 @@ mod types;
 mod upgrade;
 mod upgrade_errors;
 mod validation;
-pub mod cross_contract_safety;
-pub mod timelock;
-pub mod audit_trail;
 #[cfg(test)]
 mod edge_case_tests;
 
@@ -97,13 +94,12 @@ use common_types::{
 };
 use errors::Error;
 use fractionalization::FractionalizationModule;
-use membership_token::{MembershipToken, MembershipTokenContract};
+use membership_token::{DataKey as MembershipDataKey, MembershipToken, MembershipTokenContract};
 use staking::StakingModule;
 use subscription::SubscriptionContract;
 use types::{
     AttendanceAction, AttendanceSummary, BatchItemResult, BatchMintParams, BatchTransferParams,
     BatchUpdateParams, BatchUpgradeResult, BillingCycle, CreatePromotionParams, CreateTierParams,
-    DividendDistribution, EmergencyPauseState, FractionHolder, MembershipStatus, PauseConfig,
     PauseHistoryEntry, PauseStats, StakeInfo, StakingConfig, StakingTier, Subscription,
     SubscriptionTier, TierAnalytics, TierFeature, TierPromotion, TokenAllowance, UpdateTierParams,
     UpgradeConfig, UpgradeRecord, UserSubscriptionInfo,
@@ -282,6 +278,16 @@ impl Contract {
     }
 
     pub fn set_admin(env: Env, admin: Address) -> Result<(), Error> {
+        if let Some(current_admin) = env
+            .storage()
+            .instance()
+            .get::<MembershipDataKey, Address>(&MembershipDataKey::Admin)
+        {
+            current_admin.require_auth();
+            if current_admin != admin {
+                return Err(Error::Unauthorized);
+            }
+        }
         MembershipTokenContract::set_admin(env, admin)?;
         Ok(())
     }
@@ -1215,7 +1221,7 @@ impl Contract {
     /// * `SubscriptionNotActive` - Staking is disabled
     /// * `TierNotFound` - Tier ID does not exist
     /// * `InvalidPaymentAmount` - Amount below tier minimum
-    /// * `Unauthorized` - Caller already has a stake in a different tier
+    /// * `TierMismatch` - Caller already has a stake in a different tier
     pub fn stake_tokens(
         env: Env,
         staker: Address,
@@ -1252,6 +1258,15 @@ impl Contract {
     /// * `TokenNotFound` - No active stake found
     pub fn emergency_unstake(env: Env, staker: Address) -> Result<(), Error> {
         StakingModule::emergency_unstake(env, staker)
+    }
+
+    /// Withdraw accumulated emergency-unstake penalties to the admin.
+    pub fn withdraw_penalty_pool(
+        env: Env,
+        admin: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        StakingModule::withdraw_penalty_pool(env, admin, amount)
     }
 
     /// Get the active stake information for a staker.

--- a/contracts/manage_hub/src/staking.rs
+++ b/contracts/manage_hub/src/staking.rs
@@ -265,7 +265,7 @@ impl StakingModule {
 
             // Require the existing stake to use the same tier.
             if existing.tier_id != tier_id {
-                return Err(Error::Unauthorized);
+                return Err(Error::TierMismatch);
             }
 
             // Pull tokens from user.
@@ -424,6 +424,39 @@ impl StakingModule {
         env.events().publish(
             (String::from_str(&env, "EmergencyUnstaked"), staker.clone()),
             (amount_returned, penalty),
+        );
+
+        Ok(())
+    }
+
+    /// Withdraw accumulated emergency-unstake penalties to the admin.
+    ///
+    /// The pool is the staking-token balance held by this contract.
+    pub fn withdraw_penalty_pool(env: Env, admin: Address, amount: i128) -> Result<(), Error> {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&MembershipDataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        stored_admin.require_auth();
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+        if amount <= 0 {
+            return Err(Error::InvalidPaymentAmount);
+        }
+
+        let config = Self::get_config(&env)?;
+        let token_client = token::Client::new(&env, &config.staking_token);
+        if token_client.balance(&env.current_contract_address()) < amount {
+            return Err(Error::InsufficientBalance);
+        }
+
+        token_client.transfer(&env.current_contract_address(), &admin, &amount);
+
+        env.events().publish(
+            (String::from_str(&env, "PenaltyPoolWithdrawn"), admin),
+            amount,
         );
 
         Ok(())

--- a/contracts/manage_hub/src/test.rs
+++ b/contracts/manage_hub/src/test.rs
@@ -4039,3 +4039,89 @@ fn regression_issue_token_already_issued() {
     client.issue_token(&token_id, &user, &expiry_date);
     client.issue_token(&token_id, &user, &expiry_date);
 }
+
+#[test]
+fn regression_stake_different_tier_returns_tier_mismatch() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, sac) = setup_staking_env(&env);
+    let silver = crate::types::StakingTier {
+        id: String::from_str(&env, "silver"),
+        name: String::from_str(&env, "Silver"),
+        min_stake_amount: 1_000,
+        lock_duration: 86_400,
+        reward_multiplier_bps: 12_000,
+        base_rate_bps: 600,
+        is_active: true,
+        deactivated_at: None,
+        reactivated_at: None,
+    };
+    client.create_staking_tier(&admin, &silver);
+
+    let staker = Address::generate(&env);
+    sac.mint(&staker, &10_000);
+    client.stake_tokens(&staker, &String::from_str(&env, "bronze"), &5_000);
+
+    let result = client.try_stake_tokens(&staker, &silver.id, &1_000);
+    assert_eq!(result, Err(Ok(Error::TierMismatch)));
+    assert_eq!(client.get_stake_info(&staker).unwrap().amount, 5_000);
+}
+
+#[test]
+fn regression_set_admin_rejects_unauthorized_replacement() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+    let current_admin = Address::generate(&env);
+    let replacement = Address::generate(&env);
+
+    client.set_admin(&current_admin);
+    let result = client.try_set_admin(&replacement);
+
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    assert_eq!(
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get::<crate::membership_token::DataKey, Address>(
+                    &crate::membership_token::DataKey::Admin,
+                )
+        }),
+        Some(current_admin)
+    );
+}
+
+#[test]
+fn regression_withdraw_penalty_pool_rejects_unauthorized_and_withdraws_penalty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, sac) = setup_staking_env(&env);
+    let staker = Address::generate(&env);
+    sac.mint(&staker, &5_000);
+    client.stake_tokens(&staker, &String::from_str(&env, "bronze"), &5_000);
+    client.emergency_unstake(&staker);
+
+    let stranger = Address::generate(&env);
+    let unauthorized = client.try_withdraw_penalty_pool(&stranger, &500);
+    assert_eq!(unauthorized, Err(Ok(Error::Unauthorized)));
+
+    let before_events = env.events().all().len();
+    client.withdraw_penalty_pool(&admin, &500);
+    assert_eq!(sac.balance(&admin), 500);
+    assert_eq!(sac.balance(&env.current_contract_address()), 0);
+    assert!(env.events().all().len() > before_events);
+}
+
+#[test]
+fn regression_withdraw_penalty_pool_rejects_excess_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, _sac) = setup_staking_env(&env);
+    let result = client.try_withdraw_penalty_pool(&admin, &1);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}


### PR DESCRIPTION
PR description
Summary
Fixes manage-hub issues #260, #261, #262, and #263.

Changes
#260: Removed duplicate cross_contract_safety, timelock, and audit_trail module declarations.
#261: Require authorization from the existing admin before changing the admin address.
#262: Added a dedicated TierMismatch error for staking into a different tier.
#263: Added admin-only withdraw_penalty_pool to recover emergency-unstake penalties.
Added contract-level regression tests covering invalid and successful paths, storage preservation, balances, and event emission.

Verification
Changed-file diagnostics pass.
Rust formatting and git diff --check pass.
Full test execution remains blocked by the local environment missing the MSVC link.exe linker.

closes: #260 
closes: #261 
closes: #262 
closes: #263