### PR TITLE
fix: retry failed webhook deliveries

### DIFF
--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { BullModule } from '@nestjs/bull';
@@ -9,19 +10,17 @@ import { NotificationsController } from './notifications.controller';
 import { NotificationsGateway } from './gateway/notifications.gateway';
 import { CreateNotificationProvider } from './providers/create-notification.provider';
 import { FindNotificationsProvider } from './providers/find-notifications.provider';
+import { NotificationQueueProcessor } from './processors/notification-queue.processor';
 import { NotificationPreferencesModule } from '../notification-preferences/notification-preferences.module';
+import { DeadLetterModule } from '../common/dead-letter/dead-letter.module';
+import { WebhookService } from './services/webhook.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Notification]),
     NotificationPreferencesModule,
-import { NotificationQueueProcessor } from './processors/notification-queue.processor';
-import { DeadLetterJob } from '../common/entities/dead-letter-job.entity';
-import { DeadLetterProvider } from '../common/providers/dead-letter.provider';
-
-@Module({
-  imports: [
-    TypeOrmModule.forFeature([Notification, DeadLetterJob]),
+    HttpModule,
+    DeadLetterModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
@@ -29,16 +28,14 @@ import { DeadLetterProvider } from '../common/providers/dead-letter.provider';
       }),
       inject: [ConfigService],
     }),
-    BullModule.registerQueue(
-      {
-        name: 'notification',
-        defaultJobOptions: {
-          attempts: 3,
-          backoff: { type: 'exponential', delay: 2000 },
-          removeOnComplete: true,
-        },
+    BullModule.registerQueue({
+      name: 'notification',
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 2000 },
+        removeOnComplete: true,
       },
-    ),
+    }),
   ],
   controllers: [NotificationsController],
   providers: [
@@ -47,7 +44,7 @@ import { DeadLetterProvider } from '../common/providers/dead-letter.provider';
     CreateNotificationProvider,
     FindNotificationsProvider,
     NotificationQueueProcessor,
-    DeadLetterProvider,
+    WebhookService,
   ],
   exports: [NotificationsService],
 })

--- a/backend/src/notifications/services/webhook.service.ts
+++ b/backend/src/notifications/services/webhook.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { lastValueFrom } from 'rxjs';
+import { DeadLetterProvider } from '../../common/providers/dead-letter.provider';
 
 export interface WebhookPayload {
   eventId: string;
@@ -12,11 +13,16 @@ export interface WebhookPayload {
 export class WebhookService {
   private readonly logger = new Logger(WebhookService.name);
 
-  constructor(private readonly httpService: HttpService) {}
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly deadLetterProvider: DeadLetterProvider,
+  ) {}
 
   validatePayload(payload: WebhookPayload): void {
     if (!payload || !payload.eventId || !payload.eventType || !payload.data) {
-      throw new BadRequestException('Malformed webhook payload: missing required fields');
+      throw new BadRequestException(
+        'Malformed webhook payload: missing required fields',
+      );
     }
   }
 
@@ -30,6 +36,7 @@ export class WebhookService {
 
     let attempt = 0;
     let delay = initialDelayMs;
+    let lastError = 'Non-success response from subscriber';
 
     while (attempt < maxRetries) {
       try {
@@ -41,13 +48,32 @@ export class WebhookService {
         if (response.status >= 200 && response.status < 300) {
           return true;
         }
+
+        if (response.status < 500) {
+          return false;
+        }
+
+        lastError = `Subscriber responded with HTTP ${response.status}`;
+        throw new Error(lastError);
       } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
         this.logger.warn(
-          `Webhook delivery failed to ${targetUrl} (Attempt ${attempt}/${maxRetries}): ${error.message}`,
+          `Webhook delivery failed to ${targetUrl} (Attempt ${attempt}/${maxRetries}): ${lastError}`,
         );
 
         if (attempt >= maxRetries) {
-          throw new Error(`Webhook delivery failed after ${maxRetries} attempts`);
+          await this.deadLetterProvider.storeFailedJob({
+            queueName: 'notification',
+            jobId: payload.eventId,
+            jobName: 'deliver-webhook',
+            data: { targetUrl, payload },
+            errorMessage: lastError,
+            totalAttempts: attempt,
+            attemptsResult: { targetUrl, lastAttempt: attempt },
+          });
+          throw new Error(
+            `Webhook delivery failed after ${maxRetries} attempts`,
+          );
         }
 
         await new Promise((resolve) => setTimeout(resolve, delay));

--- a/backend/test/webhook-handler.spec.ts
+++ b/backend/test/webhook-handler.spec.ts
@@ -3,11 +3,16 @@ import { HttpService } from '@nestjs/axios';
 import { BadRequestException } from '@nestjs/common';
 import { of, throwError } from 'rxjs';
 import { AxiosResponse } from 'axios';
-import { WebhookService, WebhookPayload } from '../src/notifications/services/webhook.service';
+import {
+  WebhookService,
+  WebhookPayload,
+} from '../src/notifications/services/webhook.service';
+import { DeadLetterProvider } from '../src/common/providers/dead-letter.provider';
 
 describe('WebhookService & Retry Behavior (BE-48)', () => {
   let service: WebhookService;
   let httpService: HttpService;
+  let deadLetterProvider: { storeFailedJob: jest.Mock };
 
   const validPayload: WebhookPayload = {
     eventId: 'evt_12345',
@@ -27,19 +32,28 @@ describe('WebhookService & Retry Behavior (BE-48)', () => {
             post: jest.fn(),
           },
         },
+        {
+          provide: DeadLetterProvider,
+          useValue: { storeFailedJob: jest.fn() },
+        },
       ],
     }).compile();
 
     service = module.get<WebhookService>(WebhookService);
     httpService = module.get<HttpService>(HttpService);
+    deadLetterProvider = module.get(DeadLetterProvider);
   });
 
   describe('Payload Validation', () => {
     it('should throw BadRequestException for malformed or incomplete payload', () => {
       const invalidPayload = { eventId: 'evt_123' } as any;
 
-      expect(() => service.validatePayload(invalidPayload)).toThrow(BadRequestException);
-      expect(() => service.validatePayload(null as any)).toThrow(BadRequestException);
+      expect(() => service.validatePayload(invalidPayload)).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.validatePayload(null as any)).toThrow(
+        BadRequestException,
+      );
     });
 
     it('should pass validation for valid payload structure', () => {
@@ -59,7 +73,12 @@ describe('WebhookService & Retry Behavior (BE-48)', () => {
 
       jest.spyOn(httpService, 'post').mockReturnValue(of(mockResponse));
 
-      const result = await service.dispatchWithRetry(targetUrl, validPayload, 3, 10);
+      const result = await service.dispatchWithRetry(
+        targetUrl,
+        validPayload,
+        3,
+        10,
+      );
 
       expect(result).toBe(true);
       expect(httpService.post).toHaveBeenCalledTimes(1);
@@ -79,22 +98,67 @@ describe('WebhookService & Retry Behavior (BE-48)', () => {
         .mockReturnValueOnce(throwError(() => new Error('Network Timeout')))
         .mockReturnValueOnce(of(mockResponse));
 
-      const result = await service.dispatchWithRetry(targetUrl, validPayload, 3, 10);
+      const result = await service.dispatchWithRetry(
+        targetUrl,
+        validPayload,
+        3,
+        10,
+      );
 
       expect(result).toBe(true);
       expect(httpService.post).toHaveBeenCalledTimes(2);
+      expect(deadLetterProvider.storeFailedJob).not.toHaveBeenCalled();
+    });
+
+    it('should retry on a 5xx response and succeed if subsequent attempt passes', async () => {
+      const retryableResponse: AxiosResponse = {
+        data: {},
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: {},
+        config: {} as any,
+      };
+      const successResponse: AxiosResponse = {
+        data: { received: true },
+        status: 204,
+        statusText: 'No Content',
+        headers: {},
+        config: {} as any,
+      };
+
+      jest
+        .spyOn(httpService, 'post')
+        .mockReturnValueOnce(of(retryableResponse))
+        .mockReturnValueOnce(of(successResponse));
+
+      await expect(
+        service.dispatchWithRetry(targetUrl, validPayload, 3, 10),
+      ).resolves.toBe(true);
+      expect(httpService.post).toHaveBeenCalledTimes(2);
+      expect(deadLetterProvider.storeFailedJob).not.toHaveBeenCalled();
     });
 
     it('should fail after reaching maximum retry limit on persistent errors', async () => {
       jest
         .spyOn(httpService, 'post')
-        .mockReturnValue(throwError(() => new Error('500 Internal Server Error')));
+        .mockReturnValue(
+          throwError(() => new Error('500 Internal Server Error')),
+        );
 
       await expect(
         service.dispatchWithRetry(targetUrl, validPayload, 3, 10),
       ).rejects.toThrow('Webhook delivery failed after 3 attempts');
 
       expect(httpService.post).toHaveBeenCalledTimes(3);
+      expect(deadLetterProvider.storeFailedJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queueName: 'notification',
+          jobId: validPayload.eventId,
+          jobName: 'deliver-webhook',
+          totalAttempts: 3,
+          errorMessage: '500 Internal Server Error',
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
closes #236 
Closes #267,
Closes  #266, 
Closes #265,
Closes  #264
**PR Title:** `fix: retry failed webhook deliveries`

**Description:**

## Summary
- Retry webhook deliveries when subscribers return 5xx responses.
- Apply exponential backoff between retry attempts.
- Store exhausted deliveries in the dead-letter provider.
- Register webhook dependencies in the notifications module.
- Add focused tests for successful delivery, 5xx retries, and dead-letter persistence.

## Verification
- Focused Jest tests: 6 passed.
- ESLint passed for touched source files.
- Full build remains blocked by unrelated existing errors in `app.module.ts` and `email-queue.provider.ts`.