### PR TITLE
test: cover patch update interceptor

### DIFF
--- a/backend/src/common/interceptors/patch-update.interceptor.spec.ts
+++ b/backend/src/common/interceptors/patch-update.interceptor.spec.ts
@@ -1,0 +1,50 @@
+import { PatchUpdateInterceptor } from './patch-update.interceptor';
+
+describe('PatchUpdateInterceptor', () => {
+  let interceptor: PatchUpdateInterceptor;
+
+  beforeEach(() => {
+    interceptor = new PatchUpdateInterceptor();
+  });
+
+  it('strips undefined fields from PATCH request bodies before delegation', () => {
+    const request = {
+      method: 'PATCH',
+      body: {
+        name: 'Updated name',
+        description: undefined,
+        enabled: false,
+        clearedAt: null,
+      },
+    };
+    const next = { handle: jest.fn() };
+
+    interceptor.intercept(
+      { switchToHttp: () => ({ getRequest: () => request }) } as never,
+      next,
+    );
+
+    expect(request.body).toEqual({
+      name: 'Updated name',
+      enabled: false,
+      clearedAt: null,
+    });
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves a PATCH body without undefined fields and returns the handler result', () => {
+    const body = { name: 'Updated name', enabled: true };
+    const request = { method: 'PATCH', body };
+    const result = {};
+    const next = { handle: jest.fn().mockReturnValue(result) };
+
+    const output = interceptor.intercept(
+      { switchToHttp: () => ({ getRequest: () => request }) } as never,
+      next,
+    );
+
+    expect(request.body).toEqual(body);
+    expect(output).toBe(result);
+    expect(next.handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/common/interceptors/patch-update.interceptor.ts
+++ b/backend/src/common/interceptors/patch-update.interceptor.ts
@@ -1,13 +1,24 @@
-import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
 
+/**
+ * Removes undefined fields from PATCH request bodies before DTO validation and controller handling.
+ *
+ * Nest's built-in ClassSerializerInterceptor serializes controller responses; it does not transform
+ * incoming request bodies, so it cannot provide the request-side PATCH semantics required here.
+ */
 @Injectable()
 export class PatchUpdateInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
     if (request.method === 'PATCH') {
       request.body = Object.fromEntries(
-        Object.entries(request.body || {}).filter(([, v]) => v !== undefined)
+        Object.entries(request.body || {}).filter(([, v]) => v !== undefined),
       );
     }
     return next.handle();


### PR DESCRIPTION
closes #233 
**Title:** `test: cover patch update interceptor`

## Summary

- Document why a custom interceptor is required instead of NestJS’s `ClassSerializerInterceptor`.
- Add focused tests for `PatchUpdateInterceptor`.
- Verify `undefined` fields are stripped from PATCH bodies while `false` and `null` values are preserved.
- Verify the next handler is called and its result returned.

## Testing

- `npm test -- --runInBand common/interceptors/patch-update.interceptor.spec.ts`
- 2 tests passed.