### PR TITLE
Add workspace booking admin transfer

### DIFF
--- a/contracts/workspace_booking/src/errors.rs
+++ b/contracts/workspace_booking/src/errors.rs
@@ -36,6 +36,12 @@ pub enum Error {
     /// Invalid booking time window.
     InvalidTimeRange = 8,
 
+    /// Admin transfer proposal is invalid.
+    InvalidAdminTransfer = 9,
+
+    /// Admin transfer proposal has expired.
+    AdminTransferExpired = 10,
+
     // -----------------------------
     // Booking Errors (100–199)
     // -----------------------------

--- a/contracts/workspace_booking/src/lib.rs
+++ b/contracts/workspace_booking/src/lib.rs
@@ -20,6 +20,8 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Vec,
 };
 
+const ADMIN_TRANSFER_TTL: u64 = 86_400;
+
 // ── Storage keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -38,6 +40,16 @@ pub enum DataKey {
     MemberBookings(Address),
     /// List of booking IDs associated with a workspace.
     WorkspaceBookings(String),
+    /// Pending two-step admin transfer.
+    PendingAdminTransfer,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingAdminTransfer {
+    pub proposed_admin: Address,
+    pub proposer: Address,
+    pub expiry: u64,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -114,6 +126,94 @@ impl WorkspaceBookingContract {
 
         env.events()
             .publish((symbol_short!("init"),), (admin, payment_token));
+        Ok(())
+    }
+
+    /// Propose transferring admin control to `new_admin`.
+    ///
+    /// The proposed admin must accept before the transfer takes effect.
+    pub fn propose_admin_transfer(
+        env: Env,
+        current_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &current_admin)?;
+
+        if current_admin == new_admin {
+            return Err(Error::InvalidAdminTransfer);
+        }
+
+        let pending_transfer = PendingAdminTransfer {
+            proposed_admin: new_admin.clone(),
+            proposer: current_admin.clone(),
+            expiry: env.ledger().timestamp() + ADMIN_TRANSFER_TTL,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdminTransfer, &pending_transfer);
+
+        env.events().publish(
+            (symbol_short!("adm_prop"), new_admin.clone()),
+            current_admin,
+        );
+        Ok(())
+    }
+
+    /// Accept a pending admin transfer as the proposed admin.
+    pub fn accept_admin_transfer(env: Env, new_admin: Address) -> Result<(), Error> {
+        let pending_transfer: PendingAdminTransfer = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdminTransfer)
+            .ok_or(Error::InvalidAdminTransfer)?;
+
+        if pending_transfer.proposed_admin != new_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        if env.ledger().timestamp() > pending_transfer.expiry {
+            return Err(Error::AdminTransferExpired);
+        }
+
+        new_admin.require_auth();
+
+        let old_admin = Self::get_admin(&env)?;
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingAdminTransfer);
+
+        env.events()
+            .publish((symbol_short!("adm_xfer"), new_admin), old_admin);
+        Ok(())
+    }
+
+    /// Cancel a pending admin transfer before it is accepted.
+    pub fn cancel_admin_transfer(env: Env, current_admin: Address) -> Result<(), Error> {
+        Self::require_admin(&env, &current_admin)?;
+
+        let pending_transfer: PendingAdminTransfer = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdminTransfer)
+            .ok_or(Error::InvalidAdminTransfer)?;
+
+        if pending_transfer.proposer != current_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingAdminTransfer);
+
+        env.events().publish(
+            (
+                symbol_short!("adm_canc"),
+                pending_transfer.proposed_admin.clone(),
+            ),
+            current_admin,
+        );
         Ok(())
     }
 
@@ -592,6 +692,11 @@ impl WorkspaceBookingContract {
     /// Return the current admin address.
     pub fn admin(env: Env) -> Result<Address, Error> {
         Self::get_admin(&env)
+    }
+
+    /// Return the pending admin transfer, if one exists.
+    pub fn get_pending_admin_transfer(env: Env) -> Option<PendingAdminTransfer> {
+        env.storage().instance().get(&DataKey::PendingAdminTransfer)
     }
 
     /// Return the payment token address.

--- a/contracts/workspace_booking/src/test.rs
+++ b/contracts/workspace_booking/src/test.rs
@@ -66,6 +66,105 @@ fn test_initialize_twice_fails() {
 }
 
 #[test]
+fn test_admin_transfer_success_rotates_admin() {
+    let env = Env::default();
+    let contract_id = setup_contract(&env);
+    let client = WorkspaceBookingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &token);
+
+    let proposed_at = env.ledger().timestamp();
+    client.propose_admin_transfer(&admin, &new_admin);
+
+    let pending = client.get_pending_admin_transfer().unwrap();
+    assert_eq!(pending.proposed_admin, new_admin);
+    assert_eq!(pending.proposer, admin);
+    assert_eq!(pending.expiry, proposed_at + ADMIN_TRANSFER_TTL);
+
+    client.accept_admin_transfer(&new_admin);
+
+    assert_eq!(client.admin(), new_admin);
+    assert!(client.get_pending_admin_transfer().is_none());
+
+    let old_admin_result = client.try_register_workspace(
+        &admin,
+        &String::from_str(&env, "ws-old-admin"),
+        &String::from_str(&env, "Old Admin Desk"),
+        &WorkspaceType::HotDesk,
+        &1u32,
+        &500u128,
+    );
+    assert_eq!(old_admin_result, Err(Ok(Error::Unauthorized)));
+
+    client.register_workspace(
+        &new_admin,
+        &String::from_str(&env, "ws-new-admin"),
+        &String::from_str(&env, "New Admin Desk"),
+        &WorkspaceType::HotDesk,
+        &1u32,
+        &500u128,
+    );
+}
+
+#[test]
+fn test_admin_transfer_rejects_invalid_paths() {
+    let env = Env::default();
+    let contract_id = setup_contract(&env);
+    let client = WorkspaceBookingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let wrong_acceptor = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &token);
+
+    let non_admin_result = client.try_propose_admin_transfer(&non_admin, &new_admin);
+    assert_eq!(non_admin_result, Err(Ok(Error::Unauthorized)));
+
+    let self_transfer_result = client.try_propose_admin_transfer(&admin, &admin);
+    assert_eq!(self_transfer_result, Err(Ok(Error::InvalidAdminTransfer)));
+
+    client.propose_admin_transfer(&admin, &new_admin);
+
+    let wrong_acceptor_result = client.try_accept_admin_transfer(&wrong_acceptor);
+    assert_eq!(wrong_acceptor_result, Err(Ok(Error::Unauthorized)));
+    assert_eq!(client.admin(), admin);
+    assert!(client.get_pending_admin_transfer().is_some());
+}
+
+#[test]
+fn test_admin_transfer_expiry_and_cancel() {
+    let env = Env::default();
+    let contract_id = setup_contract(&env);
+    let client = WorkspaceBookingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin, &token);
+
+    client.propose_admin_transfer(&admin, &new_admin);
+    advance_time(&env, ADMIN_TRANSFER_TTL + 1);
+
+    let expired_result = client.try_accept_admin_transfer(&new_admin);
+    assert_eq!(expired_result, Err(Ok(Error::AdminTransferExpired)));
+    assert_eq!(client.admin(), admin);
+
+    client.cancel_admin_transfer(&admin);
+    assert!(client.get_pending_admin_transfer().is_none());
+}
+
+#[test]
 fn test_register_workspace_success() {
     let env = Env::default();
     let contract_id = setup_contract(&env);


### PR DESCRIPTION
## Overview
Adds a two-step admin transfer flow for `workspace_booking` so ownership can be rotated without directly replacing the admin key in one call.

## Related Issue
Closes #246

## Changes
- Added pending admin transfer storage with proposer, proposed admin, and 24-hour ledger-time expiry.
- Added `propose_admin_transfer`, `accept_admin_transfer`, `cancel_admin_transfer`, and `get_pending_admin_transfer` public contract methods.
- Added admin-transfer errors while preserving existing error codes.
- Added regression coverage for unauthorized/self-transfer/wrong-acceptor paths, expiry/cancel behavior, and successful admin rotation.

## Verification Results
- `cargo test -p workspace_booking` - passed, 23 tests.
- `cargo clippy -p workspace_booking --all-targets -- -D warnings` - passed.

## Acceptance Criteria
| Criteria | Status |
| --- | --- |
| Two-step admin transfer added | Done |
| Current admin must authorize proposal/cancel | Done |
| Proposed admin must authorize acceptance | Done |
| Expired transfers cannot be accepted | Done |
| Old admin loses admin-only privileges after acceptance | Done |
| Contract-level invalid and successful path tests added | Done |