### PR TITLE
fix(bookings): show signed-in email in Paystack payment options (#343)

### DIFF
--- a/frontend/app/bookings/page.tsx
+++ b/frontend/app/bookings/page.tsx
@@ -6,6 +6,7 @@ import DashboardLayout from "@/components/dashboard/DashboardLayout";
 import { useGetMyBookings } from "@/lib/react-query/hooks/bookings/useGetMyBookings";
 import { useCancelBooking } from "@/lib/react-query/hooks/bookings/useCancelBooking";
 import { useInitializePayment } from "@/lib/react-query/hooks/payments/useInitializePayment";
+import { useAuthState } from "@/lib/store/authStore";
 import { Booking, BookingStatus } from "@/lib/types/booking";
 import {
   CalendarPlus,
@@ -39,6 +40,7 @@ declare global {
 }
 
 function BookingRow({ booking, onCancelled }: { booking: Booking; onCancelled: () => void }) {
+  const { user } = useAuthState();
   const { mutateAsync: cancel, isPending: cancelling } = useCancelBooking();
   const { mutateAsync: initPayment, isPending: paying } = useInitializePayment();
   const [confirmCancel, setConfirmCancel] = useState(false);
@@ -67,7 +69,7 @@ function BookingRow({ booking, onCancelled }: { booking: Booking; onCancelled: (
       void accessCode;
       const handler = window.PaystackPop.setup({
         key: process.env.NEXT_PUBLIC_PAYSTACK_PUBLIC_KEY!,
-        email: "",
+        email: user?.email || "",
         amount: booking.totalAmount,
         ref: reference,
         onClose: () => toast.info("Payment window closed"),

--- a/frontend/components/bookings/BookingForm.tsx
+++ b/frontend/components/bookings/BookingForm.tsx
@@ -8,6 +8,7 @@ import { useGetWorkspaces } from "@/lib/react-query/hooks/workspaces/useGetWorks
 import { useCreateBooking } from "@/lib/react-query/hooks/bookings/useCreateBooking";
 import { usePriceEstimate } from "@/lib/react-query/hooks/bookings/usePriceEstimate";
 import { useInitializePayment } from "@/lib/react-query/hooks/payments/useInitializePayment";
+import { useAuthState } from "@/lib/store/authStore";
 import { PlanType } from "@/lib/types/booking";
 import {
   ArrowLeft,
@@ -48,6 +49,7 @@ declare global {
 }
 
 export default function BookingForm() {
+  const { user } = useAuthState();
   const searchParams = useSearchParams();
   const router = useRouter();
   const preselectedId = searchParams.get("workspaceId") ?? "";
@@ -136,7 +138,7 @@ export default function BookingForm() {
 
       const handler = window.PaystackPop.setup({
         key: process.env.NEXT_PUBLIC_PAYSTACK_PUBLIC_KEY!,
-        email: "", // filled by Paystack via access_code
+        email: user?.email || "",
         amount: totalAmount,
         ref: reference,
         onClose: () => toast.info("Payment window closed"),

--- a/frontend/lib/paystack.email.test.ts
+++ b/frontend/lib/paystack.email.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAuthStore } from "./store/authStore";
+import { User } from "./types/user";
+
+describe("Paystack payment email resolution and fallback", () => {
+  beforeEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  it("extracts the authenticated user's email when logged in", () => {
+    const mockUser: User = {
+      id: "user-test-123",
+      firstname: "Jane",
+      lastname: "Doe",
+      email: "jane.doe@example.com",
+      role: "user",
+      isActive: true,
+      isSuspended: false,
+      isDeleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    };
+
+    useAuthStore.getState().setUser(mockUser);
+    const user = useAuthStore.getState().user;
+    const email = user?.email || "";
+
+    expect(email).toBe("jane.doe@example.com");
+  });
+
+  it("falls back to empty string when user is unauthenticated", () => {
+    const user = useAuthStore.getState().user;
+    const email = user?.email || "";
+
+    expect(email).toBe("");
+  });
+
+  it("falls back to empty string when user email is empty string", () => {
+    const mockUser: User = {
+      id: "user-test-456",
+      firstname: "No",
+      lastname: "Email",
+      email: "",
+      role: "user",
+      isActive: true,
+      isSuspended: false,
+      isDeleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    };
+
+    useAuthStore.getState().setUser(mockUser);
+    const user = useAuthStore.getState().user;
+    const email = user?.email || "";
+
+    expect(email).toBe("");
+  });
+});


### PR DESCRIPTION
## Overview
Pass the signed-in user's email into the Paystack popup initialization across booking payment flows, with a clean fallback to an empty string when unauthenticated or when no email exists.

## Related Issue
Closes #343

## Changes
### Frontend Booking Payments
* **[MODIFY]** `frontend/app/bookings/page.tsx`
  * Imported `useAuthState` and passed `user?.email || ""` to `PaystackPop.setup` in `BookingRow`.
* **[MODIFY]** `frontend/components/bookings/BookingForm.tsx`
  * Imported `useAuthState` and passed `user?.email || ""` to `PaystackPop.setup` in `BookingForm`.
* **[ADD]** `frontend/lib/paystack.email.test.ts`
  * Added unit tests verifying authenticated user email extraction and fallback behavior.

## Verification Results
```text
✓ lib/storage.insecure.test.ts (2 tests)
✓ lib/storage.secure.test.ts (3 tests)
✓ lib/paystack.email.test.ts (3 tests)

Test Files  3 passed (3)
     Tests  8 passed (8)
```

| Acceptance Criteria | Status |
| :--- | :--- |
| Pass authenticated user's email to Paystack popup options | ✅ Passed |
| Define fallback behavior when no email exists ("") | ✅ Passed |
| Frontend unit tests and type checks pass | ✅ Passed |