### PR TITLE
feat: add an empty state to the notifications page (#353)

### DIFF
--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -44,7 +44,7 @@ function timeAgo(iso: string): string {
 
 export default function NotificationsPage() {
   const [page, setPage] = useState(1);
-  const { data, isLoading } = useGetNotifications(page, 20);
+  const { data, isLoading, isError, refetch } = useGetNotifications(page, 20);
   const markRead = useMarkNotificationRead();
   const markAll = useMarkAllRead();
 
@@ -84,13 +84,24 @@ export default function NotificationsPage() {
             />
           ))}
         </div>
+      ) : isError ? (
+        <div className="text-center py-16 text-gray-500">
+          <Bell className="w-10 h-10 mx-auto mb-3 text-gray-300" />
+          <p className="font-medium">Failed to load notifications</p>
+          <p className="text-sm mt-1">Please try again later.</p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="mt-4 text-sm text-gray-900 font-medium hover:underline"
+          >
+            Retry
+          </button>
+        </div>
       ) : notifications.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <Bell className="w-10 h-10 text-gray-200 mb-4" />
-          <p className="text-sm font-medium text-gray-500">
-            No notifications yet
-          </p>
-          <p className="text-xs text-gray-400 mt-1">
+        <div className="text-center py-16 text-gray-500">
+          <Bell className="w-10 h-10 mx-auto mb-3 text-gray-300" />
+          <p className="font-medium">No notifications yet</p>
+          <p className="text-sm mt-1">
             You&apos;ll be notified about bookings, payments, and more.
           </p>
         </div>


### PR DESCRIPTION
## Summary

Adds a dedicated error state and aligns the empty state styling on the notifications page to match the consistent pattern used across all other pages (bookings, invoices, workspaces).

## Changes

- **Error state added**: When `useGetNotifications` fails, users now see a centered error message with a Bell icon, descriptive text, and a Retry button that calls `refetch()`.
- **Empty state restyled**: Updated the existing empty state to use the same `py-16`, `text-gray-500`, `mx-auto` icon pattern used by bookings, invoices, and workspaces pages — ensuring visual consistency across the app.
- **Hook destructuring**: Added `isError` and `refetch` from the `useGetNotifications` hook.

## Before

The notifications page had no error handling — if the API call failed, users saw nothing. The empty state used different padding and icon styling than other pages.

## After

- Loading: skeleton pulse (unchanged)
- Error: Bell icon + "Failed to load notifications" + retry button
- Empty: Bell icon + "No notifications yet" + description — styled identically to other pages
- Content: notification list with pagination (unchanged)

## Verification

- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — compiled successfully, notifications page built as static

Closes #353
