### PR TITLE
fix: UX improvements — responsive nav, profile save retention, contact validation summary, invoice download feedback

### DIFF
--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -34,21 +34,40 @@ const ContactUsPage = () => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [validationSummary, setValidationSummary] = useState<string[]>([]);
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[field];
-        return newErrors;
-      });
+      const newErrors = { ...errors };
+      delete newErrors[field];
+      setErrors(newErrors);
+    }
+    // Keep the summary in sync when a previously-invalid field is corrected.
+    if (validationSummary.length > 0 && errors[field]) {
+      setValidationSummary((prev) => prev.filter((m) => !m.includes(field)));
+      if (Object.keys(errors).filter((k) => k !== field).length === 0) {
+        setValidationSummary([]);
+      }
     }
   };
 
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
+  // Field id -> human-readable label map for building the summary and focus.
+  const fieldLabels: Record<string, string> = {
+    fullName: "Full name",
+    email: "Email address",
+    subject: "Subject",
+    message: "Message",
+    phone: "Phone number",
+    company: "Company / organization",
+  };
 
+  /**
+   * Computes and stores field-level errors, returning the errors object.
+   * The fullName/email/subject/message checks mirror the existing rules.
+   */
+  const computeErrors = (): Record<string, string> => {
+    const newErrors: Record<string, string> = {};
     if (!formData.fullName.trim()) newErrors.fullName = "Full name is required";
     if (!formData.email.trim()) newErrors.email = "Email is required";
     else if (!/\S+@\S+\.\S+/.test(formData.email))
@@ -57,13 +76,46 @@ const ContactUsPage = () => {
     if (!formData.message.trim()) newErrors.message = "Message is required";
     else if (formData.message.trim().length < 10)
       newErrors.message = "Message must be at least 10 characters";
+    return newErrors;
+  };
 
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+  /**
+   * Renders a concise, form-level validation summary (issue #357). The
+   * summary is announced on submit so users don't miss field errors that sit
+   * below the fold, and the first invalid field is moved into view & focus.
+   */
+  const announceValidationSummary = (fieldErrors: Record<string, string>) => {
+    const messages = Object.entries(fieldErrors).map(
+      ([field, message]) => `${fieldLabels[field] ?? field}: ${message}`,
+    );
+    setValidationSummary([
+      `Please fix the following ${messages.length} ${
+        messages.length === 1 ? "field" : "fields"
+      }: ${messages.join(" · ")}`,
+    ]);
+
+    const firstInvalid = Object.keys(fieldErrors)[0];
+    if (firstInvalid) {
+      const el = document.getElementById(firstInvalid);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        (el as HTMLElement).focus({ preventScroll: true });
+      }
+    }
   };
 
   const handleSubmit = async () => {
-    if (!validateForm()) return;
+    // Clear the previous summary so it doesn't linger after a successful pass.
+    setValidationSummary([]);
+
+    const fieldErrors = computeErrors();
+    setErrors(fieldErrors);
+
+    // If any field failed, announce a concise summary and stop submission.
+    if (Object.keys(fieldErrors).length > 0) {
+      announceValidationSummary(fieldErrors);
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -401,6 +453,25 @@ const ContactUsPage = () => {
                     {formData.message.length} characters
                   </p>
                 </div>
+
+                {/* Form-level validation summary */}
+                {validationSummary.length > 0 && (
+                  <div
+                    role="alert"
+                    aria-live="assertive"
+                    className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700 flex items-start gap-2"
+                  >
+                    <AlertCircle className="h-5 w-5 text-red-500 mt-0.5 shrink-0" />
+                    <div>
+                      <p className="font-medium">Your message wasn't sent yet</p>
+                      {validationSummary.map((line, idx) => (
+                        <p key={idx} className="mt-1">
+                          {line}
+                        </p>
+                      ))}
+                    </div>
+                  </div>
+                )}
 
                 {/* Submit Button */}
                 <button

--- a/frontend/app/invoices/page.tsx
+++ b/frontend/app/invoices/page.tsx
@@ -23,6 +23,8 @@ function InvoiceRow({ invoice }: { invoice: Invoice }) {
   });
 
   async function handleDownload() {
+    // Prevent duplicate concurrent downloads for the same invoice.
+    if (downloading) return;
     setDownloading(true);
     try {
       const token = storage.getToken();
@@ -31,7 +33,15 @@ function InvoiceRow({ invoice }: { invoice: Invoice }) {
       const res = await fetch(`${API_BASE}/invoices/${invoice.id}/download`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
-      if (!res.ok) throw new Error("Download failed");
+      if (!res.ok) {
+        throw new Error(
+          res.status === 404
+            ? `Invoice ${invoice.invoiceNumber} could not be found for download.`
+            : res.status === 401 || res.status === 403
+              ? "You are not authorized to download this invoice."
+              : `Unable to download this invoice (status ${res.status}). Please try again.`,
+        );
+      }
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -39,8 +49,10 @@ function InvoiceRow({ invoice }: { invoice: Invoice }) {
       a.download = `${invoice.invoiceNumber}.pdf`;
       a.click();
       URL.revokeObjectURL(url);
-    } catch {
-      toast.error("Failed to download invoice");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to download invoice",
+      );
     } finally {
       setDownloading(false);
     }
@@ -83,14 +95,20 @@ function InvoiceRow({ invoice }: { invoice: Invoice }) {
         <button
           onClick={handleDownload}
           disabled={downloading}
+          aria-busy={downloading}
           className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 text-xs font-medium text-gray-600 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-40"
         >
           {downloading ? (
-            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Downloading…
+            </>
           ) : (
-            <Download className="w-3.5 h-3.5" />
+            <>
+              <Download className="w-3.5 h-3.5" />
+              PDF
+            </>
           )}
-          PDF
         </button>
       </div>
     </div>

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -236,15 +236,21 @@ export default function ProfilePage() {
             </div>
 
             {message && (
-              <p
-                className={`text-sm ${
+              <div
+                role={message.type === "error" ? "alert" : "status"}
+                className={`text-sm rounded-lg px-4 py-3 ${
                   message.type === "success"
-                    ? "text-emerald-600"
-                    : "text-red-500"
+                    ? "text-emerald-700 bg-emerald-50 border border-emerald-100"
+                    : "text-red-700 bg-red-50 border border-red-100"
                 }`}
               >
                 {message.text}
-              </p>
+                {message.type === "error" && (
+                  <span className="block mt-1 text-xs">
+                    Your changes are still here — please review and try again.
+                  </span>
+                )}
+              </div>
             )}
 
             <button

--- a/frontend/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/components/dashboard/DashboardSidebar.tsx
@@ -19,7 +19,7 @@ import {
   Bell,
   BarChart3,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useAuthState, useAuthActions } from "@/lib/store/authStore";
 import NotificationBell from "@/components/notifications/NotificationBell";
 
@@ -48,6 +48,36 @@ export default function DashboardSidebar() {
   const { logout } = useAuthActions();
   const [mobileOpen, setMobileOpen] = useState(false);
   const isAdmin = user?.role === "admin";
+  const openButtonRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeMenu = () => setMobileOpen(false);
+
+  // Issue #359: support Escape to close the mobile nav, and prevent the
+  // background content from scrolling/being obscured while the drawer is open.
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileOpen(false);
+        openButtonRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+
+    // Prevent background scroll while the drawer is open on small screens.
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    // Move focus into the drawer so keyboard/screen-reader users land on it.
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [mobileOpen]);
 
   const handleLogout = () => {
     logout();
@@ -76,7 +106,7 @@ export default function DashboardSidebar() {
             <Link
               key={item.href}
               href={item.href}
-              onClick={() => setMobileOpen(false)}
+              onClick={closeMenu}
               className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
                 active
                   ? "bg-gray-900 text-white"
@@ -102,7 +132,7 @@ export default function DashboardSidebar() {
                 <Link
                   key={item.label}
                   href={item.href}
-                  onClick={() => setMobileOpen(false)}
+                  onClick={closeMenu}
                   className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
                     active
                       ? "bg-gray-900 text-white"
@@ -151,9 +181,12 @@ export default function DashboardSidebar() {
     <>
       {/* Mobile hamburger */}
       <button
+        ref={openButtonRef}
         onClick={() => setMobileOpen(true)}
+        aria-expanded={mobileOpen}
+        aria-controls="mobile-drawer"
         className="lg:hidden fixed top-4 left-4 z-50 p-2 bg-white rounded-lg shadow-md border border-gray-200"
-        aria-label="Open menu"
+        aria-label={mobileOpen ? "Close menu" : "Open menu"}
       >
         <Menu className="w-5 h-5 text-gray-700" />
       </button>
@@ -162,18 +195,24 @@ export default function DashboardSidebar() {
       {mobileOpen && (
         <div
           className="lg:hidden fixed inset-0 z-40 bg-black/30"
-          onClick={() => setMobileOpen(false)}
+          onClick={closeMenu}
+          aria-hidden="true"
         />
       )}
 
       {/* Mobile drawer */}
       <div
+        id="mobile-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
         className={`lg:hidden fixed inset-y-0 left-0 z-50 w-64 bg-white transform transition-transform duration-200 ${
           mobileOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
         <button
-          onClick={() => setMobileOpen(false)}
+          ref={closeButtonRef}
+          onClick={closeMenu}
           className="absolute top-4 right-4 p-1"
           aria-label="Close menu"
         >


### PR DESCRIPTION
Closes #359,
Closes #358,
Closes #357,
Closes #356

## Summary
Addresses four assigned issues with focused frontend UX improvements.

### #359 — Responsive navigation: Escape close, focus management, background lock
- Added an Escape handler on the mobile drawer that closes it and restores focus to the menu button.
- Moved focus into the drawer when it opens for keyboard/screen-reader users.
- Locked body scroll while the drawer is open so background content isn't obscured/scrolled.
- Added `role="dialog"`/`aria-modal` and `aria-expanded`/`aria-controls` wiring.

### #358 — Profile: preserve values after a failed save
- Confirmed the form already retains edited values on failure (no reset on the error path).
- Surfaced the server error near the form in a clear `role="alert"/"status"` banner with an explicit note that changes are retained for retry.

### #357 — Contact: form-level validation summary
- Added a concise validation summary (`role="alert"`, `aria-live="assertive"`) shown on submit when validation fails.
- The first invalid field is scrolled into view and focused; summary clears once all fields are corrected.
- Kept field-level error messages in place.

### #356 — Invoice download feedback
- Prevented duplicate concurrent downloads for the same invoice (double-click guard on top of the disabled state).
- Filled the `aria-busy`/loading state with a visible `Downloading…` message and spinner.
- Replaced the generic failure toast with user-readable messages (404/401/403/other).

## Testing
- All four changed files typecheck cleanly under the project's strict tsconfig (with `@/*` paths).
- Note: a full `next build` is currently blocked by a **pre-existing** syntax error in `frontend/app/workspaces/page.tsx` (HTML comments inside JSX, unrelated to this change).
