### PR TITLE
Add CleanupService test for empty expired-record set

### DIFF
--- a/backend/src/cleanup/cleanup.service.spec.ts
+++ b/backend/src/cleanup/cleanup.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CleanupService } from './cleanup.service';
 import { RefreshToken } from '../auth/entities/refreshToken.entity';
@@ -80,6 +81,54 @@ describe('CleanupService', () => {
           createdAt: expect.anything(),
         }),
       );
+    });
+  });
+
+  describe('when no expired records exist', () => {
+    let errorSpy: jest.SpyInstance;
+    let logSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      mockDelete.mockResolvedValue({ affected: 0 });
+      errorSpy = jest
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation(() => undefined);
+      logSpy = jest
+        .spyOn(Logger.prototype, 'log')
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
+    it('handles no expired refresh tokens gracefully and logs no error', async () => {
+      await expect(
+        service.handleExpiredRefreshTokens(),
+      ).resolves.toBeUndefined();
+
+      expect(mockDelete).toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Removed 0'));
+    });
+
+    it('handles no stale temporary uploads gracefully and logs no error', async () => {
+      await expect(
+        service.handleStaleTemporaryUploads(),
+      ).resolves.toBeUndefined();
+
+      expect(mockDelete).toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Removed 0'));
+    });
+
+    it('handles no old audit logs gracefully and logs no error', async () => {
+      await expect(service.handleOldAuditLogs()).resolves.toBeUndefined();
+
+      expect(mockDelete).toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Removed 0'));
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extends `CleanupService` unit tests to cover the case where no expired records exist (empty result set) for all three cleanup handlers.
- Asserts the service completes without throwing and logs an informational "Removed 0" message rather than a misleading error.

## Issue
- Closes #214
- Closes https://github.com/Akazajan/Oraculum/issues/348

## Changes
- Updated `backend/src/cleanup/cleanup.service.spec.ts`:
  - Added a `when no expired records exist` describe block.
  - For each handler, the mocked `delete` returns `{ affected: 0 }`, then we assert the method resolves, `delete` is still called, `Logger.error` is never invoked, and `Logger.log` reports `Removed 0`.

## Validation
- `npx jest src/cleanup/cleanup.service.spec.ts` → 7 passed (4 existing + 3 new).
- `npx eslint src/cleanup/cleanup.service.spec.ts` → no errors.
- Not run in upstream CI here; CI lint/build/test will execute on the PR.

## Notes
- No implementation changes; the service already handles empty result sets gracefully (it logs at info level, never at error level). The new tests lock that behavior in.
