### PR TITLE
fix: preserve workspace filters in URL

### DIFF
--- a/frontend/app/workspaces/page.tsx
+++ b/frontend/app/workspaces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import DashboardLayout from "@/components/dashboard/DashboardLayout";
 import { useGetWorkspaces } from "@/lib/react-query/hooks/workspaces/useGetWorkspaces";
 import { WorkspaceType } from "@/lib/types/workspace";
@@ -22,9 +23,33 @@ const WORKSPACE_TYPES: { label: string; value: WorkspaceType | "" }[] = [
 ];
 
 export default function WorkspacesPage() {
-  const [search, setSearch] = useState("");
-  const [type, setType] = useState<WorkspaceType | "">"");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialSearch = searchParams.get("search") ?? "";
+  const initialType = searchParams.get("type") ?? "";
+
+  const [search, setSearch] = useState(initialSearch);
+  const [type, setType] = useState<WorkspaceType | "">(
+    WORKSPACE_TYPES.some((t) => t.value === initialType)
+      ? (initialType as WorkspaceType | "")
+      : ""
+  );
   const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+
+    if (search) params.set("search", search);
+    if (type) params.set("type", type);
+
+    const query = params.toString();
+
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [search, type, pathname, router]);
 
   const { data, isLoading, isError } = useGetWorkspaces({
     search: search || undefined,
@@ -46,7 +71,7 @@ export default function WorkspacesPage() {
 
   return (
     <DashboardLayout>
-      <!-- Header -->
+      {/* Header */}
       <div className="mb-8">
         <h1 className="text-2xl font-bold text-gray-900">Workspaces</h1>
         <p className="text-gray-500 mt-1 text-sm">
@@ -54,7 +79,7 @@ export default function WorkspacesPage() {
         </p>
       </div>
 
-      <!-- Filters -->
+      {/* Filters */}
       <div className="bg-white rounded-xl border border-gray-100 p-4 mb-6 flex flex-col sm:flex-row gap-3">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
@@ -62,15 +87,22 @@ export default function WorkspacesPage() {
             type="text"
             placeholder="Search workspaces..."
             value={search}
-            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
             className="w-full pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-200"
           />
         </div>
+
         <div className="relative">
           <SlidersHorizontal className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
           <select
             value={type}
-            onChange={(e) => { setType(e.target.value as WorkspaceType | ""); setPage(1); }}
+            onChange={(e) => {
+              setType(e.target.value as WorkspaceType | "");
+              setPage(1);
+            }}
             className="pl-9 pr-8 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-200 bg-white appearance-none cursor-pointer"
           >
             {WORKSPACE_TYPES.map((t) => (
@@ -80,6 +112,7 @@ export default function WorkspacesPage() {
             ))}
           </select>
         </div>
+
         {hasActiveFilters && (
           <button
             type="button"
@@ -92,7 +125,7 @@ export default function WorkspacesPage() {
         )}
       </div>
 
-      <!-- Content -->
+      {/* Content */}
       {isLoading ? (
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
           {[1, 2, 3, 4, 5, 6].map((i) => (
@@ -122,13 +155,14 @@ export default function WorkspacesPage() {
             ))}
           </div>
 
-          <!-- Pagination -->
+          {/* Pagination */}
           {meta && meta.totalPages > 1 && (
             <div className="flex items-center justify-between mt-8">
               <p className="text-sm text-gray-500">
                 Showing {(page - 1) * 9 + 1}-
                 {Math.min(page * 9, meta.total)} of {meta.total}
               </p>
+
               <div className="flex gap-2">
                 <button
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
@@ -137,6 +171,7 @@ export default function WorkspacesPage() {
                 >
                   Previous
                 </button>
+
                 <button
                   onClick={() => setPage((p) => Math.min(meta.totalPages, p + 1))}
                   disabled={page === meta.totalPages}


### PR DESCRIPTION
Closes #349

- Preserve workspace search and type filters in URL query parameters
- Restore filters from URL on page load
- Use router.replace to avoid duplicate browser history entries