### PR TITLE
fix: add structured logging to PaymentsService

### DIFF
--- a/backend/src/payments/payments.service.spec.ts
+++ b/backend/src/payments/payments.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentsService } from './payments.service';
+import { InitializePaymentProvider } from './providers/initialize-payment.provider';
+import { HandleWebhookProvider } from './providers/handle-webhook.provider';
+import { RefundPaymentProvider } from './providers/refund-payment.provider';
+import { FindPaymentsProvider } from './providers/find-payments.provider';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+  let loggerLogSpy: jest.SpyInstance;
+
+  const initializePaymentProvider = {
+    initialize: jest.fn().mockResolvedValue({
+      paymentId: 'p1',
+      authorizationUrl: 'https://example.com/pay',
+      reference: 'ref-1',
+    }),
+  };
+  const handleWebhookProvider = {
+    handle: jest.fn().mockResolvedValue(undefined),
+  };
+  const refundPaymentProvider = {
+    refund: jest.fn().mockResolvedValue({ id: 'p1' }),
+  };
+  const findPaymentsProvider = {
+    findAll: jest.fn().mockResolvedValue([]),
+    findById: jest.fn().mockResolvedValue({ id: 'p1' }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        {
+          provide: InitializePaymentProvider,
+          useValue: initializePaymentProvider,
+        },
+        { provide: HandleWebhookProvider, useValue: handleWebhookProvider },
+        { provide: RefundPaymentProvider, useValue: refundPaymentProvider },
+        { provide: FindPaymentsProvider, useValue: findPaymentsProvider },
+      ],
+    }).compile();
+
+    service = module.get(PaymentsService);
+    loggerLogSpy = jest
+      .spyOn(
+        (service as unknown as { logger: { log: (...a: unknown[]) => void } })
+          .logger,
+        'log',
+      )
+      .mockImplementation(() => undefined);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('initialize', () => {
+    it('logs the payment initialization with booking and user metadata and delegates', async () => {
+      const result = await service.initialize('booking-1', 'user-1');
+
+      expect(initializePaymentProvider.initialize).toHaveBeenCalledWith(
+        'booking-1',
+        'user-1',
+      );
+      expect(result).toEqual({
+        paymentId: 'p1',
+        authorizationUrl: 'https://example.com/pay',
+        reference: 'ref-1',
+      });
+      expect(loggerLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Initializing payment'),
+        expect.objectContaining({ bookingId: 'booking-1', userId: 'user-1' }),
+      );
+    });
+  });
+
+  describe('handleWebhook', () => {
+    it('logs the webhook receipt with the extracted reference and delegates', async () => {
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          event: 'charge.success',
+          data: { reference: 'ref-1' },
+        }),
+      );
+
+      await service.handleWebhook(rawBody, 'sig-1');
+
+      expect(handleWebhookProvider.handle).toHaveBeenCalledWith(
+        rawBody,
+        'sig-1',
+      );
+      expect(loggerLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Payment webhook received'),
+        expect.objectContaining({
+          signaturePresent: true,
+          reference: 'ref-1',
+        }),
+      );
+    });
+
+    it('logs the webhook receipt even when the body cannot be parsed', async () => {
+      const rawBody = Buffer.from('not-json');
+
+      await service.handleWebhook(rawBody, '');
+
+      expect(handleWebhookProvider.handle).toHaveBeenCalledWith(rawBody, '');
+      expect(loggerLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Payment webhook received'),
+        expect.objectContaining({
+          signaturePresent: false,
+          reference: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('refund', () => {
+    it('logs the refund attempt with metadata and delegates', async () => {
+      const result = await service.refund(
+        'payment-1',
+        'user-1',
+        UserRole.ADMIN,
+      );
+
+      expect(refundPaymentProvider.refund).toHaveBeenCalledWith(
+        'payment-1',
+        'user-1',
+        UserRole.ADMIN,
+      );
+      expect(result).toEqual({ id: 'p1' });
+      expect(loggerLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Refund requested'),
+        expect.objectContaining({
+          paymentId: 'payment-1',
+          userId: 'user-1',
+          userRole: UserRole.ADMIN,
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InitializePaymentProvider } from './providers/initialize-payment.provider';
 import { HandleWebhookProvider } from './providers/handle-webhook.provider';
 import { RefundPaymentProvider } from './providers/refund-payment.provider';
@@ -10,6 +10,8 @@ import { UserRole } from '../users/enums/userRoles.enum';
 
 @Injectable()
 export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+
   constructor(
     private readonly initializePaymentProvider: InitializePaymentProvider,
     private readonly handleWebhookProvider: HandleWebhookProvider,
@@ -18,14 +20,39 @@ export class PaymentsService {
   ) {}
 
   initialize(bookingId: string, userId: string) {
+    this.logger.log(
+      `Initializing payment for booking ${bookingId} by user ${userId}`,
+      { bookingId, userId },
+    );
     return this.initializePaymentProvider.initialize(bookingId, userId);
   }
 
   handleWebhook(rawBody: Buffer, signature: string) {
+    let reference: string | undefined;
+    try {
+      const parsed = JSON.parse(rawBody.toString()) as {
+        data?: { reference?: string };
+      };
+      reference = parsed?.data?.reference;
+    } catch {
+      // Body is validated/parsed by the provider; we only read the
+      // reference here for traceability when it is safely available.
+    }
+
+    this.logger.log(
+      `Payment webhook received${
+        reference ? ` for reference ${reference}` : ''
+      }`,
+      { signaturePresent: Boolean(signature), reference },
+    );
     return this.handleWebhookProvider.handle(rawBody, signature);
   }
 
   refund(paymentId: string, userId: string, userRole: UserRole) {
+    this.logger.log(
+      `Refund requested for payment ${paymentId} by user ${userId} (role: ${userRole})`,
+      { paymentId, userId, userRole },
+    );
     return this.refundPaymentProvider.refund(paymentId, userId, userRole);
   }
 


### PR DESCRIPTION
## Summary
PaymentsService delegated to providers without emitting any lifecycle
logs, making payment events hard to trace or audit. This adds a NestJS
`Logger` to the service and emits structured log lines at the key
lifecycle points:
- `initialize` — logs bookingId + userId
- `handleWebhook` — logs webhook receipt and extracts the Paystack
  reference for traceability (falls back gracefully on unparseable body)
- `refund` — logs paymentId, userId, and userRole

## Issue
Closes #215

## Changes
- backend/src/payments/payments.service.ts: add `Logger` and log at
  initialize / handleWebhook / refund entry points.
- backend/src/payments/payments.service.spec.ts: new focused coverage
  verifying delegation + structured log emission for success and the
  unparseable-webhook body edge case.

## Validation
- `npx eslint src/payments/payments.service.ts src/payments/payments.service.spec.ts` → clean
- `npx jest src/payments/payments.service.spec.ts` → 5/5 passing

## Notes
- The service contract (signatures, return types, DTOs, HTTP errors)
  is unchanged.
- Pre-existing repo issue (unrelated): `src/invoices/invoices.service.ts`
  has a stray `}` at line 50 that breaks ts-jest type-checking for the
  payments graph. Not touched by this PR; recommend a follow-up fix.