### PR TITLE
fix: cap unbounded exportCsv DB read with a max row limit

### DIFF
--- a/backend/src/bookings/bookings.service.spec.ts
+++ b/backend/src/bookings/bookings.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { BookingsService } from './bookings.service';
+import { CreateBookingProvider } from './providers/create-booking.provider';
+import { ConfirmBookingProvider } from './providers/confirm-booking.provider';
+import { CancelBookingProvider } from './providers/cancel-booking.provider';
+import { CompleteBookingProvider } from './providers/complete-booking.provider';
+import { FindBookingsProvider } from './providers/find-bookings.provider';
+import { ExportBookingsProvider } from './providers/export-bookings.provider';
+import { PricingService } from './pricing/pricing.service';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+describe('BookingsService', () => {
+  let service: BookingsService;
+
+  const createBookingProvider = { create: jest.fn() };
+  const confirmBookingProvider = { confirm: jest.fn() };
+  const cancelBookingProvider = { cancel: jest.fn() };
+  const completeBookingProvider = { complete: jest.fn() };
+  const findBookingsProvider = {
+    findAll: jest.fn(),
+    findById: jest.fn(),
+  };
+  const pricingService = {
+    calculateAmount: jest.fn(),
+    getPlanSummary: jest.fn(),
+  };
+  const exportBookingsProvider = {
+    findAllForExport: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookingsService,
+        { provide: CreateBookingProvider, useValue: createBookingProvider },
+        { provide: ConfirmBookingProvider, useValue: confirmBookingProvider },
+        { provide: CancelBookingProvider, useValue: cancelBookingProvider },
+        { provide: CompleteBookingProvider, useValue: completeBookingProvider },
+        { provide: FindBookingsProvider, useValue: findBookingsProvider },
+        { provide: PricingService, useValue: pricingService },
+        { provide: ExportBookingsProvider, useValue: exportBookingsProvider },
+      ],
+    }).compile();
+
+    service = module.get(BookingsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('exportCsv', () => {
+    it('delegates to the export provider with the supplied filters', async () => {
+      const rows = [{ id: 'b1' }];
+      exportBookingsProvider.findAllForExport.mockResolvedValue(rows);
+
+      const result = await service.exportCsv(
+        'user-1',
+        UserRole.USER,
+        '2024-01-01',
+        '2024-02-01',
+      );
+
+      expect(exportBookingsProvider.findAllForExport).toHaveBeenCalledWith(
+        'user-1',
+        UserRole.USER,
+        '2024-01-01',
+        '2024-02-01',
+      );
+      expect(result).toBe(rows);
+    });
+
+    it('propagates the row-cap error from the export provider', async () => {
+      exportBookingsProvider.findAllForExport.mockRejectedValue(
+        new BadRequestException(
+          'Export exceeds the maximum allowed 10000 rows.',
+        ),
+      );
+
+      await expect(service.exportCsv('user-1', UserRole.ADMIN)).rejects.toThrow(
+        /maximum allowed 10000 rows/,
+      );
+    });
+  });
+});

--- a/backend/src/bookings/providers/export-bookings.provider.spec.ts
+++ b/backend/src/bookings/providers/export-bookings.provider.spec.ts
@@ -1,0 +1,90 @@
+import { BadRequestException } from '@nestjs/common';
+import { ExportBookingsProvider } from './export-bookings.provider';
+import { UserRole } from '../../users/enums/userRoles.enum';
+
+const makeBooking = (id: string) => ({
+  id,
+  userId: 'user-1',
+  planType: 'HOURLY' as unknown as never,
+  totalAmount: 10000,
+  status: 'PENDING' as unknown as never,
+  seatCount: 1,
+  startDate: new Date().toISOString(),
+  endDate: new Date().toISOString(),
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  user: { firstname: 'A', lastname: 'B', email: 'a@b.com' },
+  workspace: { id: 'w1', name: 'WS', type: 'OPEN' as unknown as never },
+});
+
+describe('ExportBookingsProvider', () => {
+  let provider: ExportBookingsProvider;
+  let mockGetMany: jest.Mock;
+  let queryBuilder: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMany = jest.fn();
+
+    queryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: mockGetMany,
+    };
+
+    const bookingsRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+
+    provider = new ExportBookingsProvider(bookingsRepository as never);
+  });
+
+  it('returns mapped rows for a normal export', async () => {
+    mockGetMany.mockResolvedValue([makeBooking('b1'), makeBooking('b2')]);
+
+    const result = await provider.findAllForExport('user-1', UserRole.USER);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ id: 'b1', userId: 'user-1' });
+    expect(queryBuilder.take).toHaveBeenCalledWith(10_000 + 1);
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'booking.userId = :userId',
+      { userId: 'user-1' },
+    );
+  });
+
+  it('does not scope by userId for admin roles', async () => {
+    mockGetMany.mockResolvedValue([]);
+
+    await provider.findAllForExport('admin-1', UserRole.ADMIN);
+
+    expect(queryBuilder.where).not.toHaveBeenCalled();
+  });
+
+  it('throws when the export would exceed the maximum row cap', async () => {
+    mockGetMany.mockResolvedValue(
+      Array.from({ length: 10_001 }, (_, i) => makeBooking(`b${i}`)),
+    );
+
+    await expect(
+      provider.findAllForExport('user-1', UserRole.ADMIN),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    await expect(
+      provider.findAllForExport('user-1', UserRole.ADMIN),
+    ).rejects.toThrow(/maximum allowed 10000 rows/);
+  });
+
+  it('accepts exactly the maximum number of rows', async () => {
+    mockGetMany.mockResolvedValue(
+      Array.from({ length: 10_000 }, (_, i) => makeBooking(`b${i}`)),
+    );
+
+    const result = await provider.findAllForExport('user-1', UserRole.ADMIN);
+
+    expect(result).toHaveLength(10_000);
+  });
+});

--- a/backend/src/bookings/providers/export-bookings.provider.ts
+++ b/backend/src/bookings/providers/export-bookings.provider.ts
@@ -1,8 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Booking } from '../../bookings/entities/booking.entity';
 import { UserRole } from '../../users/enums/userRoles.enum';
+
+/**
+ * Hard ceiling on the number of rows a single CSV export may read into
+ * memory. Without this, an account with a very large number of bookings
+ * would load every row at once. Callers should narrow the date range
+ * when the export would exceed this limit.
+ */
+const EXPORT_MAX_ROWS = 10_000;
 
 @Injectable()
 export class ExportBookingsProvider {
@@ -51,7 +59,16 @@ export class ExportBookingsProvider {
 
     qb.orderBy('booking.createdAt', 'DESC');
 
-    const bookings = await qb.getMany();
+    // Cap the DB read so a large export cannot load every row into
+    // memory at once. We fetch one extra row to detect overflow.
+    const bookings = await qb.take(EXPORT_MAX_ROWS + 1).getMany();
+
+    if (bookings.length > EXPORT_MAX_ROWS) {
+      throw new BadRequestException(
+        `Export exceeds the maximum allowed ${EXPORT_MAX_ROWS} rows. ` +
+          'Please narrow the date range (startDate/endDate) and try again.',
+      );
+    }
 
     return bookings.map((b) => ({
       id: b.id,


### PR DESCRIPTION
## Summary
`BookingsService.exportCsv` (via ExportBookingsProvider.findAllForExport)
loaded every matching row into memory with no upper bound. This enforces
a hard maximum of 10,000 rows using a LIMIT query, and throws a
BadRequestException instructing the caller to narrow the date range when
an export would exceed the cap — preventing unbounded memory usage while
keeping the response contract stable.

## Issue
Closes #216

## Changes
- backend/src/bookings/providers/export-bookings.provider.ts: add
  EXPORT_MAX_ROWS cap; query with `.take(EXPORT_MAX_ROWS + 1)` and throw
  BadRequestException on overflow.
- backend/src/bookings/providers/export-bookings.provider.spec.ts: new
  coverage for success, admin scoping, overflow throw, and exact-max.
- backend/src/bookings/bookings.service.spec.ts: new coverage verifying
  delegation and that the cap error propagates.

## Validation
- `npx eslint` on the three files → clean
- `npx jest src/bookings/providers/export-bookings.provider.spec.ts src/bookings/bookings.service.spec.ts` → 7/7 passing

## Notes
- Service/controller/DTO contracts unchanged; only an error path was
  added (400), which is already a stable HTTP-error contract.