### PR TITLE
Add a loading state to the workspace booking action

### DIFF
--- a/frontend/app/workspaces/[id]/page.tsx
+++ b/frontend/app/workspaces/[id]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { use } from "react";
+import { use, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import DashboardLayout from "@/components/dashboard/DashboardLayout";
 import { useGetWorkspaceById } from "@/lib/react-query/hooks/workspaces/useGetWorkspaceById";
 import {
@@ -12,6 +13,7 @@ import {
   CalendarPlus,
   AlertCircle,
   RefreshCcw,
+  Loader2,
 } from "lucide-react";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -30,6 +32,17 @@ export default function WorkspaceDetailPage({
   const { id } = use(params);
   const { data, isLoading, isError, refetch } = useGetWorkspaceById(id);
   const workspace = data?.data;
+
+  // #351: track in-flight booking navigation so the CTA is disabled, shows a
+  // spinner, and duplicate requests are prevented while the booking form loads.
+  const router = useRouter();
+  const [bookingPending, setBookingPending] = useState(false);
+
+  function handleBookWorkspace() {
+    if (bookingPending || !workspace) return;
+    setBookingPending(true);
+    router.push(`/bookings/new?workspaceId=${workspace.id}`);
+  }
 
   const hourlyNaira = workspace
     ? (workspace.hourlyRate / 100).toLocaleString("en-NG", {
@@ -213,13 +226,25 @@ export default function WorkspaceDetailPage({
               </div>
 
               {workspace.isActive ? (
-                <Link
-                  href={`/bookings/new?workspaceId=${workspace.id}`}
-                  className="flex items-center justify-center gap-2 w-full py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-700 transition-colors"
+                <button
+                  type="button"
+                  onClick={handleBookWorkspace}
+                  disabled={bookingPending}
+                  aria-busy={bookingPending}
+                  className="flex items-center justify-center gap-2 w-full py-2.5 bg-gray-900 text-white text-sm font-medium rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                 >
-                  <CalendarPlus className="w-4 h-4" />
-                  Book this space
-                </Link>
+                  {bookingPending ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                      Preparing booking…
+                    </>
+                  ) : (
+                    <>
+                      <CalendarPlus className="w-4 h-4" aria-hidden="true" />
+                      Book this space
+                    </>
+                  )}
+                </button>
               ) : (
                 <button
                   disabled


### PR DESCRIPTION
Closes #351

## Description
The workspace booking call-to-action could be triggered repeatedly and gave no feedback while the booking flow was being loaded/submitted. This change adds a loading state to the action: it is disabled during submission, shows a spinner/progress label, and prevents duplicate requests.

## Changes (frontend/app/workspaces/[id]/page.tsx)
- Converted the "Book this space" CTA from a Link to a button that tracks in-flight navigation state
- The button is disabled while pending, so duplicate clicks cannot fire a second navigation
- Shows a spinner + "Preparing booking..." label during the transition
- Added aria-busy so assistive tech knows the action is in progress

## Verification
- No TypeScript errors in the changed file (repo-wide tsc failures are pre-existing in unrelated files)