### PR TITLE
fix: OTP rate limiting, workspace_sync registration, and PaystackProvider tests

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -77,6 +77,8 @@ import { CleanupModule } from './cleanup/cleanup.module';
       { name: 'newsletter', ttl: 60_000, limit: 10 },
       { name: 'contact', ttl: 60_000, limit: 5 },
       { name: 'feedback', ttl: 60_000, limit: 10 },
+      // OTP resend: 3 attempts per 60 s per IP/user (#205)
+      { name: 'otp', ttl: 60_000, limit: 3 },
 
       // Per-IP stricter limits for unauthenticated traffic (default tier).
       {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -13,6 +13,7 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
+import { Throttle, seconds } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { LoginUserDto } from './dto/login-user.dto';
@@ -65,6 +66,7 @@ export class AuthController {
   @Public()
   @Post('resend-verification-otp')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ otp: { ttl: seconds(60), limit: 3 } })
   @ApiOperation({ summary: 'Resend the registration verification OTP' })
   @ApiResponse({ status: 200, description: 'OTP re-delivered' })
   @ApiResponse({ status: 429, type: ApiErrorDto })
@@ -151,6 +153,7 @@ export class AuthController {
   @Public()
   @Post('resend-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ otp: { ttl: seconds(60), limit: 3 } })
   @ApiOperation({ summary: 'Resend a password-reset OTP' })
   resendResetPasswordVerificationOtp(@Body() resendOtpDto: ResendOtpDto) {
     return this.authService.resendResetPasswordVerificationOtp(resendOtpDto);

--- a/backend/src/payments/providers/paystack.provider.spec.ts
+++ b/backend/src/payments/providers/paystack.provider.spec.ts
@@ -1,0 +1,72 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
+import axios from 'axios';
+import { PaystackProvider } from './paystack.provider';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const SECRET = 'test-secret-key';
+
+function makeProvider(): PaystackProvider {
+  const configService = { get: jest.fn().mockReturnValue(SECRET) } as unknown as ConfigService;
+  return new PaystackProvider(configService);
+}
+
+describe('PaystackProvider', () => {
+  describe('verifyWebhookSignature', () => {
+    it('returns true for a valid signature', () => {
+      const provider = makeProvider();
+      const body = Buffer.from(JSON.stringify({ event: 'charge.success' }));
+      const sig = crypto.createHmac('sha512', SECRET).update(body).digest('hex');
+      expect(provider.verifyWebhookSignature(body, sig)).toBe(true);
+    });
+
+    it('returns false for a tampered signature', () => {
+      const provider = makeProvider();
+      const body = Buffer.from('payload');
+      expect(provider.verifyWebhookSignature(body, 'bad-sig')).toBe(false);
+    });
+  });
+
+  describe('initializeTransaction', () => {
+    it('returns authorization_url and reference on success', async () => {
+      const provider = makeProvider();
+      const responseData = {
+        authorization_url: 'https://paystack.com/pay/abc',
+        access_code: 'ac_123',
+        reference: 'ref_123',
+      };
+      mockedAxios.post = jest.fn().mockResolvedValue({ data: { data: responseData } });
+
+      const result = await provider.initializeTransaction(
+        'user@example.com', 10000, 'ref_123', 'https://callback.test',
+      );
+      expect(result.authorization_url).toBe(responseData.authorization_url);
+      expect(result.reference).toBe('ref_123');
+    });
+
+    it('propagates axios errors', async () => {
+      const provider = makeProvider();
+      mockedAxios.post = jest.fn().mockRejectedValue(new Error('Network error'));
+      await expect(
+        provider.initializeTransaction('a@b.com', 100, 'r', 'https://cb.test'),
+      ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('initiateRefund', () => {
+    it('posts to /refund and returns data', async () => {
+      const provider = makeProvider();
+      mockedAxios.post = jest.fn().mockResolvedValue({ data: { data: { id: 1 } } });
+      const result = await provider.initiateRefund('ref_123', 5000);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/refund'),
+        expect.objectContaining({ transaction: 'ref_123', amount: 5000 }),
+        expect.any(Object),
+      );
+      expect(result).toEqual({ id: 1 });
+    });
+  });
+});

--- a/backend/src/workspaces/workspaces.module.ts
+++ b/backend/src/workspaces/workspaces.module.ts
@@ -13,6 +13,7 @@ import { WarmWorkspaceCacheProvider } from './providers/warm-workspace-cache.pro
 import { AdminWorkspacesController } from './admin-workspaces.controller';
 import { AuditModule } from '../audit/audit.module';
 import { CacheInvalidationProvider } from '../common/providers/cache-invalidation.provider';
+import { WorkspaceSyncService } from '../workspace_sync';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Workspace]), AuditModule],
@@ -27,6 +28,7 @@ import { CacheInvalidationProvider } from '../common/providers/cache-invalidatio
     CheckWorkspaceAvailabilityProvider,
     WarmWorkspaceCacheProvider,
     CacheInvalidationProvider,
+    WorkspaceSyncService, // #206 — was dead code; registered here so DI can wire it
   ],
   exports: [WorkspacesService, FindWorkspaceByIdProvider, FindAllWorkspacesProvider],
 })


### PR DESCRIPTION
## Summary

Four backend fixes in one PR.

## Changes

**#205 — OTP resend rate limiting**
- Added `{ name: 'otp', ttl: 60_000, limit: 3 }` throttle tier to `AppModule.ThrottlerModule`
- Applied `@Throttle({ otp: { ttl: seconds(60), limit: 3 } })` to both `resend-verification-otp` and `resend-reset-password-otp` endpoints in `auth.controller.ts`
- Caps each endpoint to 3 calls per 60 s per IP, preventing inbox flooding

**#206 — workspace_sync.ts registered in DI**
- `WorkspaceSyncService` was an `@Injectable()` class that no module knew about
- Added it to the `providers` array in `WorkspacesModule` so NestJS can wire it

**#207 — PaystackProvider unit tests**
- New `paystack.provider.spec.ts` covering:
  - `verifyWebhookSignature` — valid HMAC-SHA512 sig returns `true`; tampered sig returns `false`
  - `initializeTransaction` — success path and network-error propagation
  - `initiateRefund` — verifies correct endpoint and payload

**#208 — HandleWebhookProvider**
- `handle-webhook.provider.spec.ts` already exists with `charge.success` and signature-rejection coverage; no further changes needed.

Closes #205, Closes #206, Closes #207, Closes #208