### PR TITLE
feat(frontend): standardize and localize booking date formatting

### DIFF
--- a/frontend/app/bookings/page.tsx
+++ b/frontend/app/bookings/page.tsx
@@ -17,6 +17,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
+import { formatDate } from "@/lib/utils";
 
 const STATUS_STYLES: Record<BookingStatus, string> = {
   PENDING: "bg-amber-50 text-amber-700",
@@ -114,14 +115,14 @@ function BookingRow({ booking, onCancelled }: { booking: Booking; onCancelled: (
             {booking.seatCount !== 1 ? "s" : ""}
           </p>
           <p className="text-xs text-gray-400 mt-0.5">
-            {booking.startDate} → {booking.endDate}
+            {formatDate(booking.startDate)} → {formatDate(booking.endDate)}
           </p>
         </div>
 
         <div className="text-right shrink-0">
           <p className="text-base font-bold text-gray-900">{amountNaira}</p>
           <p className="text-xs text-gray-400 mt-0.5">
-            {new Date(booking.createdAt).toLocaleDateString()}
+            {formatDate(booking.createdAt)}
           </p>
         </div>
       </div>

--- a/frontend/lib/utils.test.ts
+++ b/frontend/lib/utils.test.ts
@@ -1,0 +1,26 @@
+import { formatDate } from "./utils";
+import { describe, it, expect } from "vitest";
+
+describe("formatDate", () => {
+  it("formats a valid date string", () => {
+    const date = "2026-08-29T10:00:00Z";
+    expect(formatDate(date)).toBe("Aug 29, 2026");
+  });
+
+  it("formats a Date object", () => {
+    const date = new Date("2026-08-29T10:00:00Z");
+    expect(formatDate(date)).toBe("Aug 29, 2026");
+  });
+
+  it("handles undefined", () => {
+    expect(formatDate(undefined)).toBe("N/A");
+  });
+
+  it("handles null", () => {
+    expect(formatDate(null)).toBe("N/A");
+  });
+
+  it("handles invalid date strings", () => {
+    expect(formatDate("invalid-date")).toBe("Invalid date");
+  });
+});

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatDate(date: string | Date | undefined | null): string {
+  if (!date) return "N/A";
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return "Invalid date";
+  
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}


### PR DESCRIPTION
feat(frontend): standardize and localize booking date formatting

  Description
  Standardizes date formatting for booking start, end, and creation dates using a new formatDate utility function in
  frontend/lib/utils.ts. This ensures locale-consistent output and handles invalid, null, or undefined dates
  gracefully, improving user experience and data consistency in the Bookings dashboard. Includes comprehensive unit
  tests for the utility.

  Closes #345